### PR TITLE
Fix postgres broken transaction from IntegrityError catch

### DIFF
--- a/spirit/forms/comment_flag.py
+++ b/spirit/forms/comment_flag.py
@@ -4,7 +4,6 @@ from __future__ import unicode_literals
 
 from django import forms
 from django.utils.translation import ugettext_lazy as _
-from django.db import IntegrityError
 from django.utils import timezone
 
 from spirit.models.comment_flag import Flag, CommentFlag
@@ -38,11 +37,9 @@ class FlagForm(forms.ModelForm):
             self.instance.user = self.user
             self.instance.comment = self.comment
 
-            # TODO: use update_or_create on django 1.7
-            try:
-                CommentFlag.objects.create(comment=self.comment)
-            except IntegrityError:
-                CommentFlag.objects.filter(comment=self.comment)\
-                    .update(date=timezone.now())
+            CommentFlag.objects.update_or_create(
+                comment=self.comment,
+                defaults={'date': timezone.now()}
+            )
 
         return super(FlagForm, self).save(commit)

--- a/spirit/models/comment_bookmark.py
+++ b/spirit/models/comment_bookmark.py
@@ -5,7 +5,6 @@ from __future__ import unicode_literals
 from django.db import models
 from django.utils.translation import ugettext_lazy as _
 from django.conf import settings
-from django.db import IntegrityError
 from django.utils.encoding import python_2_unicode_compatible
 
 from spirit.signals.topic import topic_viewed
@@ -48,12 +47,10 @@ def topic_page_viewed_handler(sender, request, topic, **kwargs):
 
     comment_number = settings.ST_COMMENTS_PER_PAGE * (page_number - 1) + 1
 
-    # TODO: use update_or_create on django 1.7
-    try:
-        CommentBookmark.objects.create(user=request.user, topic=topic, comment_number=comment_number)
-    except IntegrityError:
-        CommentBookmark.objects.filter(user=request.user, topic=topic)\
-            .update(comment_number=comment_number)
+    CommentBookmark.objects.update_or_create(
+        user=request.user, topic=topic,
+        defaults={'comment_number': comment_number}
+    )
 
 
 topic_viewed.connect(topic_page_viewed_handler, dispatch_uid=__name__)

--- a/spirit/models/topic_notification.py
+++ b/spirit/models/topic_notification.py
@@ -112,12 +112,14 @@ def topic_private_post_create_handler(sender, topics_private, comment, **kwargs)
 def topic_private_access_pre_create_handler(sender, topic, user, **kwargs):
     # TODO: use update_or_create on django 1.7
     # change to post create
-    try:
-        TopicNotification.objects.create(user=user, topic=topic,
-                                         comment=topic.comment_set.last(), action=COMMENT,
-                                         is_active=True)
-    except IntegrityError:
-        pass
+    TopicNotification.objects.update_or_create(
+        user=user, topic=topic,
+        defaults={
+            'comment': topic.comment_set.last(),
+            'action': COMMENT,
+            'is_active': True,
+        }
+    )
 
 
 def topic_viewed_handler(sender, request, topic, **kwargs):

--- a/spirit/models/topic_unread.py
+++ b/spirit/models/topic_unread.py
@@ -6,7 +6,6 @@ from django.db import models
 from django.utils.translation import ugettext_lazy as _
 from django.conf import settings
 from django.utils import timezone
-from django.db import IntegrityError
 from django.utils.encoding import python_2_unicode_compatible
 
 from spirit.signals.comment import comment_posted
@@ -43,12 +42,10 @@ def topic_page_viewed_handler(sender, request, topic, **kwargs):
     if not request.user.is_authenticated():
         return
 
-    # TODO: use update_or_create on django 1.7
-    try:
-        TopicUnread.objects.create(user=request.user, topic=topic)
-    except IntegrityError:
-        TopicUnread.objects.filter(user=request.user, topic=topic)\
-            .update(is_read=True)
+    TopicUnread.objects.update_or_create(
+        user=request.user, topic=topic,
+        defaults={'is_read': True}
+    )
 
 
 def comment_posted_handler(sender, comment, **kwargs):


### PR DESCRIPTION
IntegrityError causes transaction erroneous state in Postgres, so, any database request after that will cause exception. Fixed by django update_or_create, as mentioned in comments before.