### PR TITLE
Added option to customize order of categories

### DIFF
--- a/spirit/admin/tests.py
+++ b/spirit/admin/tests.py
@@ -253,7 +253,8 @@ class AdminViewTest(TestCase):
         Category create
         """
         utils.login(self)
-        form_data = {"parent": "", "title": "foo", "description": "", "is_closed": False, "is_removed": False}
+        form_data = {"parent": "", "title": "foo", "description": "", "order": 10,
+                     "is_closed": False, "is_removed": False}
         response = self.client.post(reverse('spirit:admin:category:create'),
                                     form_data)
         expected_url = reverse("spirit:admin:category:index")
@@ -267,7 +268,8 @@ class AdminViewTest(TestCase):
         Category update
         """
         utils.login(self)
-        form_data = {"parent": "", "title": "foo", "description": "", "is_closed": False, "is_removed": False}
+        form_data = {"parent": "", "title": "foo", "description": "", "order": 10,
+                     "is_closed": False, "is_removed": False}
         response = self.client.post(reverse('spirit:admin:category:update', kwargs={"category_id": self.category.pk, }),
                                     form_data)
         expected_url = reverse("spirit:admin:category:index")
@@ -417,6 +419,7 @@ class AdminFormTest(TestCase):
         form_data = {"parent": "",
                      "title": "foo",
                      "description": "",
+                     "order": 10,
                      "is_closed": False,
                      "is_removed": False}
         form = CategoryForm(data=form_data)

--- a/spirit/admin/tests.py
+++ b/spirit/admin/tests.py
@@ -422,7 +422,7 @@ class AdminFormTest(TestCase):
                      "order": 10,
                      "is_closed": False,
                      "is_removed": False}
-        form = CategoryForm(data=form_data)
+        form = CategoryForm(user=self.user, data=form_data)
         self.assertEqual(form.is_valid(), True)
 
     def test_category_invalid_parent(self):
@@ -432,28 +432,28 @@ class AdminFormTest(TestCase):
         # parent can not be a subcategory, only one level subcat is allowed
         subcategory = utils.create_category(parent=self.category)
         form_data = {"parent": subcategory.pk, }
-        form = CategoryForm(data=form_data)
+        form = CategoryForm(user=self.user, data=form_data)
         self.assertEqual(form.is_valid(), False)
         self.assertNotIn('parent', form.cleaned_data)
 
         # parent can not be set to a category with childrens
         category_ = utils.create_category()
         form_data = {"parent": category_.pk, }
-        form = CategoryForm(data=form_data, instance=self.category)
+        form = CategoryForm(user=self.user, data=form_data, instance=self.category)
         self.assertEqual(form.is_valid(), False)
         self.assertNotIn('parent', form.cleaned_data)
 
         # parent can not be removed
         category_ = utils.create_category(is_removed=True)
         form_data = {"parent": category_.pk, }
-        form = CategoryForm(data=form_data)
+        form = CategoryForm(user=self.user, data=form_data)
         self.assertEqual(form.is_valid(), False)
         self.assertNotIn('parent', form.cleaned_data)
 
         # parent can not be private
         category_ = utils.create_category(is_private=True)
         form_data = {"parent": category_.pk, }
-        form = CategoryForm(data=form_data)
+        form = CategoryForm(user=self.user, data=form_data)
         self.assertEqual(form.is_valid(), False)
         self.assertNotIn('parent', form.cleaned_data)
 

--- a/spirit/category/admin/__init__.py
+++ b/spirit/category/admin/__init__.py
@@ -3,3 +3,15 @@
 from __future__ import unicode_literals
 
 default_app_config = 'spirit.category.admin.apps.SpiritCategoryAdminConfig'
+
+
+from django.contrib import admin
+from ..models import Category
+
+
+class CategoryAdmin(admin.ModelAdmin):
+    list_display = ('__str__', 'parent', 'is_closed', 'is_removed', 'is_private')
+    list_filter = ('parent',)
+
+
+admin.site.register(Category, CategoryAdmin)

--- a/spirit/category/admin/forms.py
+++ b/spirit/category/admin/forms.py
@@ -13,7 +13,7 @@ class CategoryForm(forms.ModelForm):
 
     class Meta:
         model = Category
-        fields = ("parent", "title", "description", "is_closed", "is_removed")
+        fields = ("parent", "title", "description", "order", "is_closed", "is_removed")
 
     def __init__(self, *args, **kwargs):
         super(CategoryForm, self).__init__(*args, **kwargs)

--- a/spirit/category/admin/forms.py
+++ b/spirit/category/admin/forms.py
@@ -15,9 +15,9 @@ class CategoryForm(forms.ModelForm):
         model = Category
         fields = ("parent", "title", "description", "order", "is_closed", "is_removed")
 
-    def __init__(self, *args, **kwargs):
+    def __init__(self, user, *args, **kwargs):
         super(CategoryForm, self).__init__(*args, **kwargs)
-        queryset = Category.objects.visible().parents()
+        queryset = Category.objects.visible(user).parents()
 
         if self.instance.pk:
             queryset = queryset.exclude(pk=self.instance.pk)

--- a/spirit/category/admin/views.py
+++ b/spirit/category/admin/views.py
@@ -25,13 +25,13 @@ def index(request):
 @administrator_required
 def create(request):
     if request.method == 'POST':
-        form = CategoryForm(data=request.POST)
+        form = CategoryForm(user=request.user, data=request.POST)
 
         if form.is_valid():
             form.save()
             return redirect(reverse("spirit:admin:category:index"))
     else:
-        form = CategoryForm()
+        form = CategoryForm(user=request.user)
 
     context = {'form': form, }
 
@@ -43,14 +43,14 @@ def update(request, category_id):
     category = get_object_or_404(Category, pk=category_id)
 
     if request.method == 'POST':
-        form = CategoryForm(data=request.POST, instance=category)
+        form = CategoryForm(user=request.user, data=request.POST, instance=category)
 
         if form.is_valid():
             form.save()
             messages.info(request, _("The category has been updated!"))
             return redirect(reverse("spirit:admin:category:index"))
     else:
-        form = CategoryForm(instance=category)
+        form = CategoryForm(user=request.user, instance=category)
 
     context = {'form': form, }
 

--- a/spirit/category/managers.py
+++ b/spirit/category/managers.py
@@ -15,8 +15,14 @@ class CategoryQuerySet(models.QuerySet):
     def public(self):
         return self.filter(is_private=False)
 
-    def visible(self):
-        return self.unremoved().public()
+    def visible(self, user):
+        return self.unremoved().public().for_user(user)
+
+    def for_user(self, user):
+        return self.filter(
+            Q(restrict_access=None) |
+            Q(restrict_access__contains=user.groups.all())
+        )
 
     def opened(self):
         return self.filter(Q(parent=None) | Q(parent__is_closed=False),

--- a/spirit/category/migrations/0003_auto_20150810_1911.py
+++ b/spirit/category/migrations/0003_auto_20150810_1911.py
@@ -1,0 +1,23 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import models, migrations
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('spirit_category', '0002_auto_20150728_0442'),
+    ]
+
+    operations = [
+        migrations.AlterModelOptions(
+            name='category',
+            options={'ordering': ['order', 'title', 'pk'], 'verbose_name': 'category', 'verbose_name_plural': 'categories'},
+        ),
+        migrations.AddField(
+            model_name='category',
+            name='order',
+            field=models.IntegerField(default=10, help_text='The order of the category in the list (lower number comes first)', verbose_name='order'),
+        ),
+    ]

--- a/spirit/category/migrations/0004_auto_20150812_1911.py
+++ b/spirit/category/migrations/0004_auto_20150812_1911.py
@@ -1,0 +1,30 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import models, migrations
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('auth', '0006_require_contenttypes_0002'),
+        ('spirit_category', '0003_auto_20150810_1911'),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name='category',
+            name='restrict_access',
+            field=models.ManyToManyField(related_name='categories_access', verbose_name='visible to', to='auth.Group', blank=True),
+        ),
+        migrations.AddField(
+            model_name='category',
+            name='restrict_comment',
+            field=models.ManyToManyField(related_name='categories_comment', verbose_name='comments can be posted by', to='auth.Group', blank=True),
+        ),
+        migrations.AddField(
+            model_name='category',
+            name='restrict_topic',
+            field=models.ManyToManyField(related_name='categories_topic', verbose_name='topics can be created by', to='auth.Group', blank=True),
+        ),
+    ]

--- a/spirit/category/models.py
+++ b/spirit/category/models.py
@@ -41,6 +41,12 @@ class Category(models.Model):
         verbose_name = _("category")
         verbose_name_plural = _("categories")
 
+    def __str__(self):
+        if self.parent:
+            return "%s, %s" % (self.parent.title, self.title)
+        else:
+            return self.title
+
     def get_absolute_url(self):
         if self.pk == settings.ST_TOPIC_PRIVATE_CATEGORY_PK:
             return reverse('spirit:topic:private:index')

--- a/spirit/category/models.py
+++ b/spirit/category/models.py
@@ -21,13 +21,15 @@ class Category(models.Model):
     is_closed = models.BooleanField(_("closed"), default=False)
     is_removed = models.BooleanField(_("removed"), default=False)
     is_private = models.BooleanField(_("private"), default=False)
+    order = models.IntegerField(_('order'), default=10,
+                                help_text=_('The order of the category in the list (lower number comes first)'))
 
     # topic_count = models.PositiveIntegerField(_("topic count"), default=0)
 
     objects = CategoryQuerySet.as_manager()
 
     class Meta:
-        ordering = ['title', 'pk']
+        ordering = ['order', 'title', 'pk']
         verbose_name = _("category")
         verbose_name_plural = _("categories")
 

--- a/spirit/category/models.py
+++ b/spirit/category/models.py
@@ -6,6 +6,7 @@ from django.db import models
 from django.utils.translation import ugettext_lazy as _
 from django.core.urlresolvers import reverse
 from django.conf import settings
+from django.contrib.auth.models import Group
 
 from .managers import CategoryQuerySet
 from ..core.utils.models import AutoSlugField
@@ -23,6 +24,13 @@ class Category(models.Model):
     is_private = models.BooleanField(_("private"), default=False)
     order = models.IntegerField(_('order'), default=10,
                                 help_text=_('The order of the category in the list (lower number comes first)'))
+
+    restrict_access = models.ManyToManyField(Group, blank=True, verbose_name=_('visible to'),
+                                             related_name='categories_access')
+    restrict_topic = models.ManyToManyField(Group, blank=True, verbose_name=_('topics can be created by'),
+                                            related_name='categories_topic')
+    restrict_comment = models.ManyToManyField(Group, blank=True, verbose_name=_('comments can be posted by'),
+                                              related_name='categories_comment')
 
     # topic_count = models.PositiveIntegerField(_("topic count"), default=0)
 

--- a/spirit/category/tests.py
+++ b/spirit/category/tests.py
@@ -39,6 +39,20 @@ class CategoryViewTest(TestCase):
             [self.uncategorized, self.category_1, self.category_2]
         )
 
+    def test_category_list_view_order(self):
+        """
+        categories should be ordered by the order field first
+        """
+        response = self.client.get(reverse('spirit:category:index'))
+        self.category_2.order = 1
+        self.category_2.save()
+        self.category_1.order = 2
+        self.category_1.save()
+        self.assertEqual(
+            list(response.context['categories']),
+            [self.category_2, self.category_1, self.uncategorized]
+        )
+
     def test_category_detail_view(self):
         """
         should display all topics in the category and its subcategories

--- a/spirit/category/views.py
+++ b/spirit/category/views.py
@@ -14,14 +14,14 @@ from .models import Category
 
 
 def detail(request, pk, slug):
-    category = get_object_or_404(Category.objects.visible(),
+    category = get_object_or_404(Category.objects.visible(request.user),
                                  pk=pk)
 
     if category.slug != slug:
         return HttpResponsePermanentRedirect(category.get_absolute_url())
 
     subcategories = Category.objects\
-        .visible()\
+        .visible(request.user)\
         .children(parent=category)
 
     topics = Topic.objects\
@@ -50,4 +50,6 @@ class IndexView(ListView):
 
     template_name = 'spirit/category/index.html'
     context_object_name = "categories"
-    queryset = Category.objects.visible().parents()
+
+    def get_queryset(self):
+        return Category.objects.visible(self.request.user).parents()

--- a/spirit/comment/admin.py
+++ b/spirit/comment/admin.py
@@ -1,0 +1,11 @@
+from django.contrib import admin
+from .models import Comment
+
+
+class CommentAdmin(admin.ModelAdmin):
+    list_display = ('__str__', 'topic', 'date')
+    list_filter = ('topic__category',)
+    raw_id_fields = ('user', 'topic')
+
+
+admin.site.register(Comment, CommentAdmin)

--- a/spirit/comment/managers.py
+++ b/spirit/comment/managers.py
@@ -28,8 +28,14 @@ class CommentQuerySet(models.QuerySet):
     def public(self):
         return self.filter(topic__category__is_private=False)
 
-    def visible(self):
-        return self.unremoved().public()
+    def visible(self, user):
+        return self.unremoved().public().for_user(user)
+
+    def for_user(self, user):
+        return self.filter(
+            Q(topic__category__restrict_access=None) |
+            Q(topic__category__restrict_access__contains=user.groups.all())
+        )
 
     def for_topic(self, topic):
         return self.filter(topic=topic)

--- a/spirit/comment/models.py
+++ b/spirit/comment/models.py
@@ -49,6 +49,9 @@ class Comment(models.Model):
         verbose_name = _("comment")
         verbose_name_plural = _("comments")
 
+    def __str__(self):
+        return "%s - %s" % (self.date, self.user)
+
     def get_absolute_url(self):
         return reverse('spirit:comment:find', kwargs={'pk': str(self.id), })
 

--- a/spirit/core/utils/timezone.py
+++ b/spirit/core/utils/timezone.py
@@ -2,7 +2,7 @@
 
 from __future__ import unicode_literals
 
-from django.utils.translation import ugettext as _
+from django.utils.translation import ugettext_lazy as _
 
 
 TIMEZONE_CHOICES = [

--- a/spirit/search/forms.py
+++ b/spirit/search/forms.py
@@ -39,7 +39,7 @@ class BasicSearchForm(BaseSearchForm):
 
 class AdvancedSearchForm(BaseSearchForm):
 
-    category = forms.ModelMultipleChoiceField(queryset=Category.objects.visible(),
+    category = forms.ModelMultipleChoiceField(queryset=Category.objects.unremoved().public(),
                                               required=False,
                                               label=_('Filter by'),
                                               widget=forms.CheckboxSelectMultiple)

--- a/spirit/topic/admin/__init__.py
+++ b/spirit/topic/admin/__init__.py
@@ -3,3 +3,16 @@
 from __future__ import unicode_literals
 
 default_app_config = 'spirit.topic.admin.apps.SpiritTopicAdminConfig'
+
+
+from django.contrib import admin
+from ..models import Topic
+
+
+class TopicAdmin(admin.ModelAdmin):
+    list_display = ('__str__', 'category', 'date', 'user')
+    list_filter = ('category',)
+    raw_id_fields = ('user',)
+
+
+admin.site.register(Topic, TopicAdmin)

--- a/spirit/topic/forms.py
+++ b/spirit/topic/forms.py
@@ -19,7 +19,7 @@ class TopicForm(forms.ModelForm):
     def __init__(self, user, *args, **kwargs):
         super(TopicForm, self).__init__(*args, **kwargs)
         self.user = user
-        self.fields['category'] = NestedModelChoiceField(queryset=Category.objects.visible().opened(),
+        self.fields['category'] = NestedModelChoiceField(queryset=Category.objects.visible(user).opened(),
                                                          related_name='category_set',
                                                          parent_field='parent_id',
                                                          label_field='title',

--- a/spirit/topic/models.py
+++ b/spirit/topic/models.py
@@ -38,6 +38,9 @@ class Topic(models.Model):
         verbose_name = _("topic")
         verbose_name_plural = _("topics")
 
+    def __str__(self):
+        return "%s" % self.title
+
     def get_absolute_url(self):
         if self.category_id == settings.ST_TOPIC_PRIVATE_CATEGORY_PK:
             return reverse('spirit:topic:private:detail', kwargs={'topic_id': str(self.id), 'slug': self.slug})

--- a/spirit/topic/views.py
+++ b/spirit/topic/views.py
@@ -25,7 +25,7 @@ from . import utils
 @ratelimit(rate='1/10s')
 def publish(request, category_id=None):
     if category_id:
-        get_object_or_404(Category.objects.visible(),
+        get_object_or_404(Category.objects.visible(request.user),
                           pk=category_id)
 
     if request.method == 'POST':
@@ -119,11 +119,11 @@ def detail(request, pk, slug):
 
 def index_active(request):
     categories = Category.objects\
-        .visible()\
+        .visible(request.user)\
         .parents()
 
     topics = Topic.objects\
-        .visible()\
+        .visible(request.user)\
         .with_bookmarks(user=request.user)\
         .order_by('-is_globally_pinned', '-last_active')\
         .select_related('category')

--- a/spirit/user/admin/__init__.py
+++ b/spirit/user/admin/__init__.py
@@ -3,3 +3,14 @@
 from __future__ import unicode_literals
 
 default_app_config = 'spirit.user.admin.apps.SpiritUserAdminConfig'
+
+
+from django.contrib import admin
+from ..models import UserProfile
+
+
+class UserProfileAdmin(admin.ModelAdmin):
+    list_display = ('__str__', 'last_seen', 'is_verified', 'is_administrator', 'is_moderator')
+
+
+admin.site.register(UserProfile, UserProfileAdmin)

--- a/spirit/user/models.py
+++ b/spirit/user/models.py
@@ -34,6 +34,9 @@ class UserProfile(models.Model):
         verbose_name = _("forum profile")
         verbose_name_plural = _("forum profiles")
 
+    def __str__(self):
+        return "%s" % self.user
+
     def save(self, *args, **kwargs):
         if self.user.is_superuser:
             self.is_administrator = True

--- a/spirit/user/views.py
+++ b/spirit/user/views.py
@@ -124,7 +124,7 @@ def _activity(request, pk, slug, queryset, template, reverse_to, context_name, p
 
 def topics(request, pk, slug):
     user_topics = Topic.objects\
-        .visible()\
+        .visible(request.user)\
         .with_bookmarks(user=request.user)\
         .filter(user_id=pk)\
         .order_by('-date', '-pk')\
@@ -142,7 +142,7 @@ def topics(request, pk, slug):
 
 def comments(request, pk, slug):
     user_comments = Comment.objects\
-        .visible()\
+        .visible(request.user)\
         .filter(user_id=pk)
 
     return _activity(
@@ -157,7 +157,7 @@ def comments(request, pk, slug):
 
 def likes(request, pk, slug):
     user_comments = Comment.objects\
-        .visible()\
+        .visible(request.user)\
         .filter(comment_likes__user_id=pk)\
         .order_by('-comment_likes__date', '-pk')
 


### PR DESCRIPTION
It's very common to want to be able to manually specify the order of your categories. For example, a "News" or "FAQ" category will have better visibility if it's on top.

I added an "order" field to Category and also added a test. This change is backwards compatible.