### PR TITLE
get_facebook_share_url parameter modified

### DIFF
--- a/spirit/core/tags/social_share.py
+++ b/spirit/core/tags/social_share.py
@@ -27,7 +27,7 @@ def _compose_tweet(title):
 @register.simple_tag(takes_context=True)
 def get_facebook_share_url(context, url, title):
     request = context['request']
-    params = [('u', "100"),
+    params = [('s', "100"),
               ('p[url]', request.build_absolute_uri(url)),
               ('p[title]', title)]
     return FACEBOOK_URL % urlencode(params)

--- a/spirit/core/tests/tests_utils.py
+++ b/spirit/core/tests/tests_utils.py
@@ -208,7 +208,7 @@ class UtilsTemplateTagTests(TestCase):
                      '{% get_email_share_url url="/á/foo bar/" title="á" %}'
                      '{% get_share_url url="/á/foo bar/" %}')
         res = t.render(Context({'request': RequestFactory().get('/'), }))
-        self.assertEqual(res.strip(), "http://www.facebook.com/sharer.php?u=100&p%5Burl%5D=http%3A%2F%2Ftestserver"
+        self.assertEqual(res.strip(), "http://www.facebook.com/sharer.php?s=100&p%5Burl%5D=http%3A%2F%2Ftestserver"
                                       "%2F%25C3%25A1%2Ffoo%2520bar%2F&p%5Btitle%5D=%C3%A1"
                                       "https://twitter.com/share?url=http%3A%2F%2Ftestserver%2F%25C3%25A1%2F"
                                       "foo%2520bar%2F&text=%C3%A1"


### PR DESCRIPTION
A parameter 'u' is modified to 's' in function 'get_facebook_share_url'

ref:
http://community.spirit-project.com/topic/283/can-you-share-a-post-to-facebook/#c2