### PR TITLE
Added basic topic tagging support

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,6 @@
 Django>=1.8,<1.9
 django-haystack>=2.4,<2.5
+django-taggit>=0.18.0,<1.0.0
 whoosh>=2.7,<2.8
 mistune==0.7.1
 Pillow>=3.0,<3.1

--- a/spirit/search/search_indexes.py
+++ b/spirit/search/search_indexes.py
@@ -3,20 +3,19 @@
 from __future__ import unicode_literals
 
 from django.conf import settings
-
 from haystack import indexes
 
 from ..topic.models import Topic
 
 
 class TopicIndex(indexes.SearchIndex, indexes.Indexable):
-
     text = indexes.CharField(document=True, use_template=True)
     title = indexes.CharField(model_attr='title')
     category_id = indexes.IntegerField(model_attr='category_id')
     is_removed = indexes.BooleanField(model_attr='is_removed')
     is_category_removed = indexes.BooleanField(model_attr='category__is_removed')
     is_subcategory_removed = indexes.BooleanField(model_attr='category__parent__is_removed', default=False)
+    tags = indexes.MultiValueField()
 
     def get_model(self):
         return Topic
@@ -25,3 +24,6 @@ class TopicIndex(indexes.SearchIndex, indexes.Indexable):
         """Used when the entire index for model is updated."""
         topics = super(TopicIndex, self).index_queryset(using=using)
         return topics.exclude(category_id=settings.ST_TOPIC_PRIVATE_CATEGORY_PK)
+
+    def prepare_tags(self, obj):
+        return [tag.name for tag in obj.tags.all()]

--- a/spirit/search/templates/search/indexes/spirit_topic/topic_text.txt
+++ b/spirit/search/templates/search/indexes/spirit_topic/topic_text.txt
@@ -1,1 +1,5 @@
 {{ object.title }}
+
+{% for tag in object.tags.all %}
+{{ tag.name }}
+{% endfor %}

--- a/spirit/search/tests.py
+++ b/spirit/search/tests.py
@@ -67,10 +67,34 @@ class SearchViewTest(TestCase):
         self.topic = utils.create_topic(category=self.category, user=self.user, title="spirit search test foo")
         self.topic2 = utils.create_topic(category=self.category, user=self.user, title="foo")
 
+        self.topic.tags.add('tag', 'apple')
+        self.topic2.tags.add('tag', 'banana')
+
         call_command("rebuild_index", verbosity=0, interactive=False)
 
     # def tearDown(self):
         # haystack.connections = self.connections
+
+    def assert_search_returns_topics(self, data, expected_topics):
+        """
+        Verify the expected topics are returned by the search endpoint.
+
+        Arguments:
+            data (dict): Data passed to the search endpoint.
+            expected_topics (List[Topic]): List of topics expected to be returned by the endpoint.
+        """
+        response = self.client.get(reverse('spirit:search:search'), data)
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual([s.object for s in response.context['page']], expected_topics)
+
+    def test_search_tag(self):
+        """
+        search by topic tag
+        """
+        utils.login(self)
+        self.assert_search_returns_topics({'q': 'apple'}, [self.topic])
+        self.assert_search_returns_topics({'q': 'banana'}, [self.topic2])
+        self.assert_search_returns_topics({'q': 'tag'}, [self.topic2, self.topic])
 
     def test_advanced_search_detail(self):
         """
@@ -85,11 +109,7 @@ class SearchViewTest(TestCase):
         advanced search by topic
         """
         utils.login(self)
-        data = {'q': 'spirit search', }
-        response = self.client.get(reverse('spirit:search:search'),
-                                   data)
-        self.assertEqual(response.status_code, 200)
-        self.assertEqual([s.object for s in response.context['page']], [self.topic, ])
+        self.assert_search_returns_topics({'q': 'spirit search'}, [self.topic])
 
     @override_djconfig(topics_per_page=1)
     def test_advanced_search_topics_paginate(self):
@@ -97,11 +117,7 @@ class SearchViewTest(TestCase):
         advanced search by topic paginated
         """
         utils.login(self)
-        data = {'q': 'foo', }
-        response = self.client.get(reverse('spirit:search:search'),
-                                   data)
-        self.assertEqual(response.status_code, 200)
-        self.assertEqual([s.object for s in response.context['page']], [self.topic2, ])
+        self.assert_search_returns_topics({'q': 'foo'}, [self.topic2])
 
     def test_advanced_search_in_category(self):
         """
@@ -109,14 +125,12 @@ class SearchViewTest(TestCase):
         """
         utils.login(self)
         category = utils.create_category()
+
         data = {'q': 'spirit search', 'category': category.pk}
-        response = self.client.get(reverse('spirit:search:search'),
-                                   data)
-        self.assertEqual(list(response.context['page']), [])
+        self.assert_search_returns_topics(data, [])
 
         data['category'] = self.category.pk
-        response = self.client.get(reverse('spirit:search:search'),
-                                   data)
+        response = self.client.get(reverse('spirit:search:search'), data)
         self.assertEqual(len(response.context['page']), 1)
 
 

--- a/spirit/settings.py
+++ b/spirit/settings.py
@@ -159,3 +159,11 @@ HAYSTACK_CONNECTIONS = {
         'PATH': os.path.join(os.path.dirname(__file__), 'search/whoosh_index'),
     },
 }
+
+# django-taggit
+
+INSTALLED_APPS += [
+    'taggit',
+]
+
+TAGGIT_CASE_INSENSITIVE = True

--- a/spirit/topic/models.py
+++ b/spirit/topic/models.py
@@ -9,6 +9,8 @@ from django.core.urlresolvers import reverse
 from django.conf import settings
 from django.utils import timezone
 from django.db.models import F
+from taggit.managers import TaggableManager
+
 
 from .managers import TopicQuerySet
 from ..core.utils.models import AutoSlugField
@@ -33,6 +35,7 @@ class Topic(models.Model):
     comment_count = models.PositiveIntegerField(_("comment count"), default=0)
 
     objects = TopicQuerySet.as_manager()
+    tags = TaggableManager()
 
     class Meta:
         ordering = ['-last_active', '-pk']


### PR DESCRIPTION
django-taggit has been added to associate topics with one, or more, tags. This only addresses the backend support. Frontend/UI support is still needed.

See #96 

@nitely @sirex please take a look