### PR TITLE
Fix two persistent XSS flaws

### DIFF
--- a/spirit/core/utils/markdown/renderer.py
+++ b/spirit/core/utils/markdown/renderer.py
@@ -6,6 +6,7 @@ import mistune
 
 
 class Renderer(mistune.Renderer):
+    PROTOCOL_WHITELIST = ('http', 'https', 'ftp')
 
     # Override
     def autolink(self, link, is_email=False):
@@ -19,10 +20,18 @@ class Renderer(mistune.Renderer):
 
         return '<a href="%s">%s</a>' % (link, text)
 
+    def is_valid_link(self, link):
+        if ':' not in link:
+            return False
+        protocol, _ = link.split(':', 1)
+        return protocol in self.PROTOCOL_WHITELIST
+
     # Override
     def link(self, link, title, text):
-        if link.startswith('javascript:'):
+        if not self.is_valid_link(link):
             link = ''
+
+        link = mistune.escape(link, quote=True)
 
         if not title:
             if self.options['no_follow']:


### PR DESCRIPTION
I guess I owe you a bit of explanation for this pull request out of the blue: There are two distinct XSS vulnerabilities in the forum's markdown parser. Both affect the `[text](url)` link syntax.

1. While the code attempts to prevent javascript:-Links, it actually fails to do so. An attacker can use entities to bypass the check, as browsers will first decode the entities when encountered in attribute values. An exemplary exploit would be ``[text](javascript&colon;alert`1`) `` (the payload uses the backtick to avoid parantheses). This exploit is however not the only one concerning the URL parsing. In Firefox, the following payload suffices to create a link which will run on the same origin as the page: ``[text](data:text/html,<script>alert`1`</script>) ``. Additionally, there is vbscript: and a range of extremely evil protocol handlers. Thus, the patch uses a whitelist to prevent all of this in one swoop. One drawback is that relative and kinda-relative URLs do not work in the link tag anymore (/from/root/path and path/to/something). Its up to you to decide if this is acceptable.

2. The second exploit actually uses the lack of escaping on the link itself. Here is an attack vector: ``[text]("><script>alert`1`</script>) ``. Simple, but works. The solution is to simply escape the link, too. This is the more dangerous attack of the two as it does not require user interaction. It was found by @TheJH.