### PR TITLE
Support for YouTube embeds that have a timestamp

### DIFF
--- a/spirit/core/tests/tests_markdown.py
+++ b/spirit/core/tests/tests_markdown.py
@@ -190,7 +190,10 @@ class UtilsMarkdownTests(TestCase):
         comment = (
             "https://www.youtube.com/watch?v=Z0UISCEe52Y\n"
             "https://www.youtube.com/watch?v=Z0UISCEe52Y&t=1m13s\n"
+            "https://www.youtube.com/watch?v=O1QQajfobPw&t=1h1m38s\n"
+            "https://www.youtube.com/watch?v=O1QQajfobPw&feature=youtu.be&t=3698\n"
             "http://youtu.be/afyK1HSFfgw\n"
+            "http://youtu.be/O1QQajfobPw?t=1h1m38s\n"
             "https://www.youtube.com/embed/vsF0K3Ou1v0\n"
             "https://www.youtube.com/watch?v=<bad>\n"
             "https://www.noyoutube.com/watch?v=Z0UISCEe52Y\n"
@@ -205,8 +208,14 @@ class UtilsMarkdownTests(TestCase):
                 'allowfullscreen></iframe></span>',
                 '<span class="video"><iframe src="https://www.youtube.com/embed/Z0UISCEe52Y?html5=1&start=73" '
                 'allowfullscreen></iframe></span>',
+                '<span class="video"><iframe src="https://www.youtube.com/embed/O1QQajfobPw?html5=1&start=3698" '
+                'allowfullscreen></iframe></span>',
+                '<span class="video"><iframe src="https://www.youtube.com/embed/O1QQajfobPw?html5=1&start=3698" '
+                'allowfullscreen></iframe></span>',
                 '<span class="video"><iframe src="https://www.youtube.com/embed/afyK1HSFfgw?html5=1"'
                 ' allowfullscreen></iframe></span>',
+                '<span class="video"><iframe src="https://www.youtube.com/embed/O1QQajfobPw?html5=1&start=3698" '
+                'allowfullscreen></iframe></span>',
                 '<span class="video"><iframe src="https://www.youtube.com/embed/vsF0K3Ou1v0?html5=1"'
                 ' allowfullscreen></iframe></span>',
                 '<p><a rel="nofollow" href="https://www.youtube.com/watch?v=">'

--- a/spirit/core/tests/tests_markdown.py
+++ b/spirit/core/tests/tests_markdown.py
@@ -191,6 +191,7 @@ class UtilsMarkdownTests(TestCase):
             "https://www.youtube.com/watch?v=Z0UISCEe52Y\n"
             "https://www.youtube.com/watch?v=Z0UISCEe52Y&t=1m13s\n"
             "https://www.youtube.com/watch?v=O1QQajfobPw&t=1h1m38s\n"
+            "https://www.youtube.com/watch?v=O1QQajfobPw&t=105m\n"
             "https://www.youtube.com/watch?v=O1QQajfobPw&feature=youtu.be&t=3698\n"
             "http://youtu.be/afyK1HSFfgw\n"
             "http://youtu.be/O1QQajfobPw?t=1h1m38s\n"
@@ -209,6 +210,8 @@ class UtilsMarkdownTests(TestCase):
                 '<span class="video"><iframe src="https://www.youtube.com/embed/Z0UISCEe52Y?html5=1&start=73" '
                 'allowfullscreen></iframe></span>',
                 '<span class="video"><iframe src="https://www.youtube.com/embed/O1QQajfobPw?html5=1&start=3698" '
+                'allowfullscreen></iframe></span>',
+                '<span class="video"><iframe src="https://www.youtube.com/embed/O1QQajfobPw?html5=1&start=6300" '
                 'allowfullscreen></iframe></span>',
                 '<span class="video"><iframe src="https://www.youtube.com/embed/O1QQajfobPw?html5=1&start=3698" '
                 'allowfullscreen></iframe></span>',

--- a/spirit/core/tests/tests_markdown.py
+++ b/spirit/core/tests/tests_markdown.py
@@ -189,6 +189,7 @@ class UtilsMarkdownTests(TestCase):
         """
         comment = (
             "https://www.youtube.com/watch?v=Z0UISCEe52Y\n"
+            "https://www.youtube.com/watch?v=Z0UISCEe52Y&t=1m13s\n"
             "http://youtu.be/afyK1HSFfgw\n"
             "https://www.youtube.com/embed/vsF0K3Ou1v0\n"
             "https://www.youtube.com/watch?v=<bad>\n"
@@ -201,6 +202,8 @@ class UtilsMarkdownTests(TestCase):
             comment_md.splitlines(),
             [
                 '<span class="video"><iframe src="https://www.youtube.com/embed/Z0UISCEe52Y?html5=1" '
+                'allowfullscreen></iframe></span>',
+                '<span class="video"><iframe src="https://www.youtube.com/embed/Z0UISCEe52Y?html5=1&start=73" '
                 'allowfullscreen></iframe></span>',
                 '<span class="video"><iframe src="https://www.youtube.com/embed/afyK1HSFfgw?html5=1"'
                 ' allowfullscreen></iframe></span>',

--- a/spirit/core/utils/markdown/block.py
+++ b/spirit/core/utils/markdown/block.py
@@ -55,8 +55,10 @@ class BlockGrammar(mistune.BlockGrammar):
         r'|youtu\.be/'
         r'|youtube\.com/embed/)'
         r'(?P<id>[a-zA-Z0-9_\-]{11})'
-        r'((&|\?)?feature=youtu\.be)?'
-        r'((&|\?)?t=(?P<start_hours>[0-9]+h)?(?P<start_minutes>[0-9]+m)?(?P<start_seconds>[0-9]+s?)?)?'
+        r'((&|\?)('
+        r'|(t=(?P<start_hours>[0-9]{1,2}h)?(?P<start_minutes>[0-9]{1,4}m)?(?P<start_seconds>[0-9]{1,5}s?)?)'
+        r'|([^&\s]+)'
+        r')){,10}'
         r'(?:\n+|$)'
     )
 

--- a/spirit/core/utils/markdown/block.py
+++ b/spirit/core/utils/markdown/block.py
@@ -55,7 +55,7 @@ class BlockGrammar(mistune.BlockGrammar):
         r'|youtu\.be/'
         r'|youtube\.com/embed/)'
         r'(?P<id>[a-zA-Z0-9_\-]{11})'
-        r'((&|\?)?feature=youtu.be)?'
+        r'((&|\?)?feature=youtu\.be)?'
         r'((&|\?)?t=(?P<start_hours>[0-9]+h)?(?P<start_minutes>[0-9]+m)?(?P<start_seconds>[0-9]+s?)?)?'
         r'(?:\n+|$)'
     )

--- a/spirit/core/utils/markdown/block.py
+++ b/spirit/core/utils/markdown/block.py
@@ -39,6 +39,7 @@ class BlockGrammar(mistune.BlockGrammar):
 
     # Try to get the video ID. Works for URLs of the form:
     # * https://www.youtube.com/watch?v=Z0UISCEe52Y
+    # * https://www.youtube.com/watch?v=Z0UISCEe52Y&t=1m30s
     # * http://youtu.be/afyK1HSFfgw
     # * https://www.youtube.com/embed/vsF0K3Ou1v0
     youtube = re.compile(
@@ -47,6 +48,7 @@ class BlockGrammar(mistune.BlockGrammar):
         r'|youtu\.be/'
         r'|youtube\.com/embed/)'
         r'(?P<id>[a-zA-Z0-9_\-]{11})'
+        r'(&t=(?P<start_minutes>[0-9]+m)?(?P<start_seconds>[0-9]+s)?)?'
         r'(?:\n+|$)'
     )
 
@@ -138,7 +140,9 @@ class BlockLexer(mistune.BlockLexer):
     def parse_youtube(self, m):
         self.tokens.append({
             'type': 'youtube',
-            'video_id': m.group("id")
+            'video_id': m.group("id"),
+            'start_minutes': m.group("start_minutes"),
+            'start_seconds': m.group("start_seconds"),
         })
 
     def parse_vimeo(self, m):

--- a/spirit/core/utils/markdown/block.py
+++ b/spirit/core/utils/markdown/block.py
@@ -39,16 +39,24 @@ class BlockGrammar(mistune.BlockGrammar):
 
     # Try to get the video ID. Works for URLs of the form:
     # * https://www.youtube.com/watch?v=Z0UISCEe52Y
-    # * https://www.youtube.com/watch?v=Z0UISCEe52Y&t=1m30s
     # * http://youtu.be/afyK1HSFfgw
     # * https://www.youtube.com/embed/vsF0K3Ou1v0
+    #
+    # Also works for timestamps:
+    # * https://www.youtube.com/watch?v=Z0UISCEe52Y&t=1m30s
+    # * https://www.youtube.com/watch?v=O1QQajfobPw&t=1h1m38s
+    # * https://www.youtube.com/watch?v=O1QQajfobPw&feature=youtu.be&t=3698
+    # * https://youtu.be/O1QQajfobPw?t=3698
+    # * https://youtu.be/O1QQajfobPw?t=1h1m38s
+    #
     youtube = re.compile(
         r'^https?://(www\.)?'
         r'(youtube\.com/watch\?v='
         r'|youtu\.be/'
         r'|youtube\.com/embed/)'
         r'(?P<id>[a-zA-Z0-9_\-]{11})'
-        r'(&t=(?P<start_minutes>[0-9]+m)?(?P<start_seconds>[0-9]+s)?)?'
+        r'((&|\?)?feature=youtu.be)?'
+        r'((&|\?)?t=(?P<start_hours>[0-9]+h)?(?P<start_minutes>[0-9]+m)?(?P<start_seconds>[0-9]+s?)?)?'
         r'(?:\n+|$)'
     )
 
@@ -141,6 +149,7 @@ class BlockLexer(mistune.BlockLexer):
         self.tokens.append({
             'type': 'youtube',
             'video_id': m.group("id"),
+            'start_hours': m.group("start_hours"),
             'start_minutes': m.group("start_minutes"),
             'start_seconds': m.group("start_seconds"),
         })

--- a/spirit/core/utils/markdown/markdown.py
+++ b/spirit/core/utils/markdown/markdown.py
@@ -48,7 +48,8 @@ class Markdown(mistune.Markdown):
         return self.renderer.video_link(link=self.token['link'])
 
     def output_youtube(self):
-        return self.renderer.youtube(video_id=self.token['video_id'])
+        return self.renderer.youtube(video_id=self.token['video_id'], start_minutes=self.token['start_minutes'],
+                                     start_seconds=self.token['start_seconds'])
 
     def output_vimeo(self):
         return self.renderer.vimeo(video_id=self.token['video_id'])

--- a/spirit/core/utils/markdown/markdown.py
+++ b/spirit/core/utils/markdown/markdown.py
@@ -48,7 +48,9 @@ class Markdown(mistune.Markdown):
         return self.renderer.video_link(link=self.token['link'])
 
     def output_youtube(self):
-        return self.renderer.youtube(video_id=self.token['video_id'], start_minutes=self.token['start_minutes'],
+        return self.renderer.youtube(video_id=self.token['video_id'],
+                                     start_hours=self.token['start_hours'],
+                                     start_minutes=self.token['start_minutes'],
                                      start_seconds=self.token['start_seconds'])
 
     def output_vimeo(self):

--- a/spirit/core/utils/markdown/renderer.py
+++ b/spirit/core/utils/markdown/renderer.py
@@ -96,9 +96,18 @@ class Renderer(mistune.Renderer):
         return '<video controls><source src="{link}">' \
                '<a rel="nofollow" href="{link}">{link}</a></video>\n'.format(link=link)
 
-    def youtube(self, video_id):
-        return '<span class="video"><iframe src="https://www.youtube.com/embed/{video_id}?html5=1" ' \
-               'allowfullscreen></iframe></span>\n'.format(video_id=video_id)
+    def youtube(self, video_id, start_minutes=None, start_seconds=None):
+        timestamp = 0
+        try:
+            if start_minutes:
+                timestamp += int(start_minutes[:-1]) * 60
+            if start_seconds:
+                timestamp += int(start_seconds[:-1])
+        except ValueError:
+            pass
+        timestamp = ('&start=%s' % timestamp) if timestamp else ''
+        return '<span class="video"><iframe src="https://www.youtube.com/embed/{video_id}?html5=1{timestamp}" ' \
+               'allowfullscreen></iframe></span>\n'.format(video_id=video_id, timestamp=timestamp)
 
     def vimeo(self, video_id):
         return '<span class="video"><iframe src="https://player.vimeo.com/video/{video_id}" ' \

--- a/spirit/core/utils/markdown/renderer.py
+++ b/spirit/core/utils/markdown/renderer.py
@@ -96,12 +96,14 @@ class Renderer(mistune.Renderer):
         return '<video controls><source src="{link}">' \
                '<a rel="nofollow" href="{link}">{link}</a></video>\n'.format(link=link)
 
-    def youtube(self, video_id, start_minutes=None, start_seconds=None):
+    def youtube(self, video_id, start_hours=None, start_minutes=None, start_seconds=None):
         timestamp = 0
+        if start_hours:
+            timestamp += int(start_hours.replace('h', '')) * 60 * 60
         if start_minutes:
-            timestamp += int(start_minutes[:-1]) * 60
+            timestamp += int(start_minutes.replace('m', '')) * 60
         if start_seconds:
-            timestamp += int(start_seconds[:-1])
+            timestamp += int(start_seconds.replace('s', ''))
         timestamp = ('&start=%s' % timestamp) if timestamp else ''
         return '<span class="video"><iframe src="https://www.youtube.com/embed/{video_id}?html5=1{timestamp}" ' \
                'allowfullscreen></iframe></span>\n'.format(video_id=video_id, timestamp=timestamp)

--- a/spirit/core/utils/markdown/renderer.py
+++ b/spirit/core/utils/markdown/renderer.py
@@ -98,13 +98,10 @@ class Renderer(mistune.Renderer):
 
     def youtube(self, video_id, start_minutes=None, start_seconds=None):
         timestamp = 0
-        try:
-            if start_minutes:
-                timestamp += int(start_minutes[:-1]) * 60
-            if start_seconds:
-                timestamp += int(start_seconds[:-1])
-        except ValueError:
-            pass
+        if start_minutes:
+            timestamp += int(start_minutes[:-1]) * 60
+        if start_seconds:
+            timestamp += int(start_seconds[:-1])
         timestamp = ('&start=%s' % timestamp) if timestamp else ''
         return '<span class="video"><iframe src="https://www.youtube.com/embed/{video_id}?html5=1{timestamp}" ' \
                'allowfullscreen></iframe></span>\n'.format(video_id=video_id, timestamp=timestamp)


### PR DESCRIPTION
Youtube links with timestamps like &t=10m30s would not get embedded previously.

Unfortunately the embed url [does not take the same arguments](https://developers.google.com/youtube/player_parameters#start) so there is some additional parsing, but tests are included 🌟 !