### PR TITLE
Feature/rate limit own cache 120

### DIFF
--- a/example/project/settings/base.py
+++ b/example/project/settings/base.py
@@ -19,6 +19,9 @@ BASE_DIR = os.path.dirname(os.path.dirname(os.path.dirname(__file__)))
 
 # Application definition
 
+# This will be the default in next version
+ST_RATELIMIT_CACHE = 'st_rate_limit'
+
 # Extend the Spirit installed apps.
 # Check out the spirit.settings.py so you do not end up with duplicated apps.
 INSTALLED_APPS.extend([

--- a/example/project/settings/dev.py
+++ b/example/project/settings/dev.py
@@ -38,6 +38,11 @@ CACHES.update({
     'default': {
         'BACKEND': 'django.core.cache.backends.locmem.LocMemCache',
     },
+    'st_rate_limit': {
+        'BACKEND': 'django.core.cache.backends.locmem.LocMemCache',
+        'LOCATION': 'spirit_rl_cache',
+        'TIMEOUT': None
+    }
 })
 
 PASSWORD_HASHERS = [

--- a/spirit/admin/tests.py
+++ b/spirit/admin/tests.py
@@ -4,7 +4,6 @@ from __future__ import unicode_literals
 
 from django.test import TestCase, RequestFactory
 from django.core.urlresolvers import reverse
-from django.core.cache import cache
 from django.core.exceptions import PermissionDenied
 from django.contrib.auth import get_user_model
 
@@ -27,7 +26,7 @@ User = get_user_model()
 class AdminViewTest(TestCase):
 
     def setUp(self):
-        cache.clear()
+        utils.cache_clear()
         self.user = utils.create_user()
         self.user.st.is_administrator = True
         self.user.st.save()
@@ -343,7 +342,7 @@ class AdminViewTest(TestCase):
 class AdminFormTest(TestCase):
 
     def setUp(self):
-        cache.clear()
+        utils.cache_clear()
         self.user = utils.create_user()
         self.category = utils.create_category()
         self.topic = utils.create_topic(self.category)

--- a/spirit/category/admin/tests.py
+++ b/spirit/category/admin/tests.py
@@ -4,7 +4,6 @@ from __future__ import unicode_literals
 
 from django.test import TestCase, RequestFactory
 from django.core.urlresolvers import reverse
-from django.core.cache import cache
 from django.core.exceptions import PermissionDenied
 from django.contrib.auth import get_user_model
 
@@ -19,7 +18,7 @@ User = get_user_model()
 class AdminViewTest(TestCase):
 
     def setUp(self):
-        cache.clear()
+        utils.cache_clear()
         self.user = utils.create_user()
         self.user.st.is_administrator = True
         self.user.st.save()
@@ -87,7 +86,7 @@ class AdminViewTest(TestCase):
 class AdminFormTest(TestCase):
 
     def setUp(self):
-        cache.clear()
+        utils.cache_clear()
         self.user = utils.create_user()
         self.category = utils.create_category()
         self.topic = utils.create_topic(self.category)

--- a/spirit/category/tests.py
+++ b/spirit/category/tests.py
@@ -6,7 +6,6 @@ import datetime
 
 from django.test import TestCase
 from django.core.urlresolvers import reverse
-from django.core.cache import cache
 from django.utils import timezone
 from django.conf import settings
 
@@ -21,7 +20,7 @@ from .models import Category
 class CategoryViewTest(TestCase):
 
     def setUp(self):
-        cache.clear()
+        utils.cache_clear()
         self.user = utils.create_user()
         self.category_1 = utils.create_category(title="cat1")
         self.subcategory_1 = utils.create_subcategory(self.category_1)
@@ -152,7 +151,7 @@ class CategoryViewTest(TestCase):
 class CategoryMigrationTest(TestCase):
 
     def setUp(self):
-        cache.clear()
+        utils.cache_clear()
 
     def test_uncategorized_category(self):
         """

--- a/spirit/comment/bookmark/tests.py
+++ b/spirit/comment/bookmark/tests.py
@@ -2,10 +2,9 @@
 
 from __future__ import unicode_literals
 
-from django.test import TestCase, RequestFactory
+from django.test import TestCase
 from django.core.urlresolvers import reverse
 from django.template import Template, Context
-from django.core.cache import cache
 
 from djconfig import config
 
@@ -17,7 +16,7 @@ from .forms import BookmarkForm
 class CommentBookmarkViewTest(TestCase):
 
     def setUp(self):
-        cache.clear()
+        utils.cache_clear()
         self.user = utils.create_user()
         self.category = utils.create_category()
         self.topic = utils.create_topic(category=self.category, user=self.user)
@@ -38,7 +37,7 @@ class CommentBookmarkViewTest(TestCase):
 class CommentBookmarkModelsTest(TestCase):
 
     def setUp(self):
-        cache.clear()
+        utils.cache_clear()
         self.user = utils.create_user()
         self.category = utils.create_category()
         self.topic = utils.create_topic(category=self.category, user=self.user)
@@ -91,7 +90,7 @@ class CommentBookmarkFormTest(TestCase):
 class CommentBookmarkTemplateTagsTest(TestCase):
 
     def setUp(self):
-        cache.clear()
+        utils.cache_clear()
         self.user = utils.create_user()
         self.category = utils.create_category()
         self.topic = utils.create_topic(self.category)

--- a/spirit/comment/flag/tests.py
+++ b/spirit/comment/flag/tests.py
@@ -4,7 +4,6 @@ from __future__ import unicode_literals
 
 from django.test import TestCase
 from django.core.urlresolvers import reverse
-from django.core.cache import cache
 
 from ...core.tests import utils
 from .models import Flag, CommentFlag
@@ -14,7 +13,7 @@ from .forms import FlagForm
 class FlagViewTest(TestCase):
 
     def setUp(self):
-        cache.clear()
+        utils.cache_clear()
         self.user = utils.create_user()
         self.category = utils.create_category()
         self.topic = utils.create_topic(category=self.category, user=self.user)
@@ -36,7 +35,7 @@ class FlagViewTest(TestCase):
 class FlagFormTest(TestCase):
 
     def setUp(self):
-        cache.clear()
+        utils.cache_clear()
         self.user = utils.create_user()
         self.category = utils.create_category()
         self.topic = utils.create_topic(category=self.category, user=self.user)

--- a/spirit/comment/history/tests.py
+++ b/spirit/comment/history/tests.py
@@ -5,7 +5,6 @@ from datetime import timedelta
 
 from django.test import TestCase
 from django.core.urlresolvers import reverse
-from django.core.cache import cache
 
 from djconfig.utils import override_djconfig
 
@@ -17,7 +16,7 @@ from . import models
 class CommentHistoryViewTest(TestCase):
 
     def setUp(self):
-        cache.clear()
+        utils.cache_clear()
         self.user = utils.create_user()
         self.category = utils.create_category()
         self.topic = utils.create_topic(category=self.category, user=self.user)
@@ -113,7 +112,7 @@ class CommentHistoryViewTest(TestCase):
 class CommentHistoryModelsTest(TestCase):
 
     def setUp(self):
-        cache.clear()
+        utils.cache_clear()
         self.user = utils.create_user()
         self.category = utils.create_category()
         self.topic = utils.create_topic(category=self.category, user=self.user)

--- a/spirit/comment/like/tests.py
+++ b/spirit/comment/like/tests.py
@@ -5,7 +5,6 @@ from __future__ import unicode_literals
 from django.test import TestCase
 from django.core.urlresolvers import reverse
 from django.template import Template, Context
-from django.core.cache import cache
 
 from ...core.tests import utils
 from ..models import Comment
@@ -17,7 +16,7 @@ from .tags import render_like_form
 class LikeViewTest(TestCase):
 
     def setUp(self):
-        cache.clear()
+        utils.cache_clear()
         self.user = utils.create_user()
         self.category = utils.create_category()
         self.topic = utils.create_topic(category=self.category, user=self.user)
@@ -106,7 +105,7 @@ class LikeViewTest(TestCase):
 class LikeFormTest(TestCase):
 
     def setUp(self):
-        cache.clear()
+        utils.cache_clear()
         self.user = utils.create_user()
         self.category = utils.create_category()
         self.topic = utils.create_topic(category=self.category, user=self.user)
@@ -137,7 +136,7 @@ class LikeFormTest(TestCase):
 class LikeTemplateTagsTest(TestCase):
 
     def setUp(self):
-        cache.clear()
+        utils.cache_clear()
         self.user = utils.create_user()
         self.category = utils.create_category()
         self.topic = utils.create_topic(category=self.category, user=self.user)

--- a/spirit/comment/poll/tests.py
+++ b/spirit/comment/poll/tests.py
@@ -4,7 +4,6 @@ from __future__ import unicode_literals
 
 from django.test import TestCase, RequestFactory
 from django.core.urlresolvers import reverse
-from django.core.cache import cache
 from django.contrib.auth import get_user_model
 from django.utils import timezone
 from django.template import Template, Context
@@ -22,7 +21,7 @@ User = get_user_model()
 class PollViewTest(TestCase):
 
     def setUp(self):
-        cache.clear()
+        utils.cache_clear()
         self.user = utils.create_user()
         self.user2 = utils.create_user()
         self.category = utils.create_category()
@@ -234,7 +233,7 @@ class PollViewTest(TestCase):
 class PollFormTest(TestCase):
 
     def setUp(self):
-        cache.clear()
+        utils.cache_clear()
         self.user = utils.create_user()
         self.user2 = utils.create_user()
         self.category = utils.create_category()
@@ -384,7 +383,7 @@ class PollFormTest(TestCase):
 class CommentPollTemplateTagsTest(TestCase):
 
     def setUp(self):
-        cache.clear()
+        utils.cache_clear()
         self.user = utils.create_user()
         self.category = utils.create_category()
         self.topic = utils.create_topic(category=self.category)
@@ -536,7 +535,7 @@ class CommentPollTemplateTagsTest(TestCase):
 class PollModelsTest(TestCase):
 
     def setUp(self):
-        cache.clear()
+        utils.cache_clear()
         self.user = utils.create_user()
         self.category = utils.create_category()
         self.topic = utils.create_topic(category=self.category, user=self.user)
@@ -775,7 +774,7 @@ class PollModelsTest(TestCase):
 class PollUtilsTest(TestCase):
 
     def setUp(self):
-        cache.clear()
+        utils.cache_clear()
         self.user = utils.create_user()
         self.category = utils.create_category()
         self.topic = utils.create_topic(category=self.category, user=self.user)

--- a/spirit/comment/tests.py
+++ b/spirit/comment/tests.py
@@ -7,7 +7,6 @@ import json
 import shutil
 
 from django.test import TestCase, RequestFactory
-from django.core.cache import cache
 from django.core.urlresolvers import reverse
 from django.template import Template, Context
 from django.core.exceptions import PermissionDenied
@@ -39,7 +38,7 @@ User = get_user_model()
 class CommentViewTest(TestCase):
 
     def setUp(self):
-        cache.clear()
+        utils.cache_clear()
         self.user = utils.create_user()
         self.category = utils.create_category()
         self.topic = utils.create_topic(category=self.category, user=self.user)
@@ -402,7 +401,7 @@ class CommentViewTest(TestCase):
 class CommentModelsTest(TestCase):
 
     def setUp(self):
-        cache.clear()
+        utils.cache_clear()
         self.user = utils.create_user()
         self.category = utils.create_category()
         self.topic = utils.create_topic(category=self.category, user=self.user)
@@ -442,7 +441,7 @@ class CommentModelsTest(TestCase):
 class CommentTemplateTagTests(TestCase):
 
     def setUp(self):
-        cache.clear()
+        utils.cache_clear()
         self.user = utils.create_user()
         self.category = utils.create_category()
         self.topic = utils.create_topic(category=self.category, user=self.user)
@@ -477,7 +476,7 @@ class CommentTemplateTagTests(TestCase):
 class CommentFormTest(TestCase):
 
     def setUp(self):
-        cache.clear()
+        utils.cache_clear()
         self.user = utils.create_user()
         self.category = utils.create_category()
         self.topic = utils.create_topic(category=self.category)
@@ -601,7 +600,7 @@ class CommentFormTest(TestCase):
 class CommentUtilsTest(TestCase):
 
     def setUp(self):
-        cache.clear()
+        utils.cache_clear()
         self.user = utils.create_user()
         self.category = utils.create_category()
         self.topic = utils.create_topic(category=self.category, user=self.user)

--- a/spirit/core/tests/tests_markdown.py
+++ b/spirit/core/tests/tests_markdown.py
@@ -2,13 +2,12 @@
 
 from __future__ import unicode_literals
 
-from django.core.cache import cache
 from django.test import TestCase
 from django.test.utils import override_settings
 from django.utils import translation
 from django.utils import timezone
 
-from ..tests import utils as test_utils
+from . import utils
 from ..utils.markdown import Markdown, quotify
 
 
@@ -18,10 +17,10 @@ now_fixed = timezone.now()
 class UtilsMarkdownTests(TestCase):
 
     def setUp(self):
-        cache.clear()
-        self.user = test_utils.create_user(username="nitely")
-        self.user2 = test_utils.create_user(username="esteban")
-        self.user3 = test_utils.create_user(username="áéíóú")
+        utils.cache_clear()
+        self.user = utils.create_user(username="nitely")
+        self.user2 = utils.create_user(username="esteban")
+        self.user3 = utils.create_user(username="áéíóú")
 
     def test_markdown_escape(self):
         """

--- a/spirit/core/tests/tests_utils.py
+++ b/spirit/core/tests/tests_utils.py
@@ -6,7 +6,6 @@ import datetime
 import json
 import os
 
-from django.core.cache import cache
 from django.test import TestCase, RequestFactory
 from django.test.utils import override_settings
 from django.template import Template, Context
@@ -28,7 +27,7 @@ from ..utils.forms import NestedModelChoiceField
 from ..utils.timezone import TIMEZONE_CHOICES
 from ..utils.decorators import moderator_required, administrator_required
 from ..tags import time as ttags_utils
-from ..tests import utils as test_utils
+from . import utils as test_utils
 from ..tags.messages import render_messages
 
 User = get_user_model()
@@ -37,7 +36,7 @@ User = get_user_model()
 class UtilsTests(TestCase):
 
     def setUp(self):
-        cache.clear()
+        test_utils.cache_clear()
 
     def test_render_form_errors(self):
         """
@@ -268,7 +267,7 @@ class UtilsTimezoneTests(TestCase):
 class UtilsDecoratorsTests(TestCase):
 
     def setUp(self):
-        cache.clear()
+        test_utils.cache_clear()
         self.user = test_utils.create_user()
 
     def test_moderator_required(self):

--- a/spirit/core/tests/tests_utils_deprecations.py
+++ b/spirit/core/tests/tests_utils_deprecations.py
@@ -1,0 +1,23 @@
+# -*- coding: utf-8 -*-
+
+from __future__ import unicode_literals
+import warnings
+
+from django.test import TestCase
+
+from ..utils import deprecations
+
+
+class UtilsDeprecations(TestCase):
+
+    def setUp(self):
+        pass
+
+    def test_warn(self):
+        with warnings.catch_warnings(record=True) as w:
+            deprecations.warn("foo")
+            self.assertEqual(len(w), 1)
+            self.assertTrue(issubclass(
+                w[-1].category,
+                deprecations.RemovedInNextVersionWarning))
+            self.assertTrue('foo' in str(w[-1].message))

--- a/spirit/core/tests/tests_utils_paginator.py
+++ b/spirit/core/tests/tests_utils_paginator.py
@@ -2,7 +2,6 @@
 
 from __future__ import unicode_literals
 
-from django.core.cache import cache
 from django.test import TestCase, RequestFactory
 from django.template import Template, Context
 from django.test.utils import override_settings
@@ -21,7 +20,7 @@ from ..tags import paginator as ttag_paginator
 class UtilsPaginatorTest(TestCase):
 
     def setUp(self):
-        cache.clear()
+        utils.cache_clear()
 
     def test_paginator_page(self):
         per_page = 15
@@ -52,7 +51,7 @@ class UtilsPaginatorTest(TestCase):
 class UtilsInfinitePaginatorTest(TestCase):
 
     def setUp(self):
-        cache.clear()
+        utils.cache_clear()
         self.user = utils.create_user()
         self.topic = utils.create_topic(utils.create_category())
 
@@ -96,7 +95,7 @@ class UtilsInfinitePaginatorTest(TestCase):
 class UtilsYTPaginatorTests(TestCase):
 
     def setUp(self):
-        cache.clear()
+        utils.cache_clear()
         self.user = utils.create_user()
         self.topic = utils.create_topic(utils.create_category())
 
@@ -168,7 +167,7 @@ class UtilsYTPaginatorTests(TestCase):
 class UtilsYTPaginatorTemplateTagsTests(TestCase):
 
     def setUp(self):
-        cache.clear()
+        utils.cache_clear()
 
     def tests_yt_paginate(self):
         # first page
@@ -233,7 +232,7 @@ class UtilsYTPaginatorTemplateTagsTests(TestCase):
 class UtilsPaginatorTemplateTagsTests(TestCase):
 
     def setUp(self):
-        cache.clear()
+        utils.cache_clear()
 
     def tests_paginate(self):
         # first page

--- a/spirit/core/tests/tests_utils_ratelimit.py
+++ b/spirit/core/tests/tests_utils_ratelimit.py
@@ -2,13 +2,13 @@
 
 from __future__ import unicode_literals
 
-from django.core.cache import cache
 from django.test import TestCase, RequestFactory
 from django.contrib.auth.models import AnonymousUser, User
 from django.contrib.messages.storage.fallback import FallbackStorage
 from django.conf import settings
 from django.core.cache import caches
 
+from . import utils
 from ..utils.ratelimit import ratelimit as rl_module
 from ..utils.ratelimit import RateLimit
 from ..utils.ratelimit.decorators import ratelimit
@@ -26,7 +26,7 @@ def setup_request_factory_messages(req):
 class UtilsRateLimitTests(TestCase):
 
     def setUp(self):
-        cache.clear()
+        utils.cache_clear()
 
     def test_rate_limit_split_rate(self):
         req = RequestFactory().post('/')

--- a/spirit/core/tests/utils.py
+++ b/spirit/core/tests/utils.py
@@ -4,7 +4,7 @@ from __future__ import unicode_literals
 
 from django.contrib.auth import get_user_model
 from django.conf import settings
-from django.core.cache import caches
+from django.core.cache import caches, cache
 
 from ...topic.models import Topic
 from ...category.models import Category
@@ -80,4 +80,7 @@ def login(test_case_instance, user=None, password=None):
 
 
 def cache_clear():
-    [c.clear() for c in caches.all()]
+    cache.clear()  # Default one
+
+    for c in caches.all():
+        c.clear()

--- a/spirit/core/tests/utils.py
+++ b/spirit/core/tests/utils.py
@@ -4,6 +4,7 @@ from __future__ import unicode_literals
 
 from django.contrib.auth import get_user_model
 from django.conf import settings
+from django.core.cache import caches
 
 from ...topic.models import Topic
 from ...category.models import Category
@@ -76,3 +77,7 @@ def login(test_case_instance, user=None, password=None):
     password = password or "bar"
     login_successful = test_case_instance.client.login(username=user.username, password=password)
     test_case_instance.assertTrue(login_successful)
+
+
+def cache_clear():
+    [c.clear() for c in caches.all()]

--- a/spirit/core/utils/deprecations.py
+++ b/spirit/core/utils/deprecations.py
@@ -1,0 +1,22 @@
+# -*- coding: utf-8 -*-
+
+from __future__ import unicode_literals
+import warnings
+
+__all__ = [
+    'RemovedInNextVersionWarning',
+    'warn']
+
+
+class RemovedInNextVersionWarning(DeprecationWarning):
+    """"""
+
+
+def warn(message):
+    warnings.warn(
+        message,
+        RemovedInNextVersionWarning,
+        stacklevel=2)
+
+
+warnings.simplefilter("default", RemovedInNextVersionWarning)

--- a/spirit/core/utils/deprecations.py
+++ b/spirit/core/utils/deprecations.py
@@ -12,11 +12,11 @@ class RemovedInNextVersionWarning(DeprecationWarning):
     """"""
 
 
-def warn(message):
+def warn(message, stacklevel=3):
     warnings.warn(
         message,
-        RemovedInNextVersionWarning,
-        stacklevel=2)
+        category=RemovedInNextVersionWarning,
+        stacklevel=stacklevel)
 
 
 warnings.simplefilter("default", RemovedInNextVersionWarning)

--- a/spirit/core/utils/ratelimit/ratelimit.py
+++ b/spirit/core/utils/ratelimit/ratelimit.py
@@ -24,16 +24,15 @@ def validate_cache_config():
 
     # Some third-party backend
     # don't have a TIMEOUT option
-    if (not settings.ST_RATELIMIT_IGNORE_TIMEOUT_WARNING and
+    if (not settings.ST_RATELIMIT_SKIP_TIMEOUT_CHECK and
             cache.get('TIMEOUT', 1) is not None):
         # todo: raise ConfigurationError in next version
         # todo: warn(
         #   'settings.ST_RATELIMIT_CACHE cache's TIMEOUT '
-        #   'must be None (never expire) and it should '
-        #   'be other than the default. See spirit.settings. '
-        #   'To ignore this warning, set '
-        #   'settings.ST_RATELIMIT_IGNORE_TIMEOUT to True, '
-        #   'if you know what you are doing.')
+        #   'must be None (never expire) and it may '
+        #   'be other than the default. '
+        #   'To skip this check, set '
+        #   'settings.ST_RATELIMIT_SKIP_TIMEOUT_CHECK to True.')
         pass
 
 

--- a/spirit/core/utils/ratelimit/ratelimit.py
+++ b/spirit/core/utils/ratelimit/ratelimit.py
@@ -8,6 +8,8 @@ import time
 from django.conf import settings
 from django.core.cache import caches
 
+from ..deprecations import warn
+
 
 TIME_DICT = {
     's': 1,
@@ -22,18 +24,17 @@ def validate_cache_config():
         # this cache so we do nothing
         return
 
-    # Some third-party backend
-    # don't have a TIMEOUT option
     if (not settings.ST_RATELIMIT_SKIP_TIMEOUT_CHECK and
             cache.get('TIMEOUT', 1) is not None):
-        # todo: raise ConfigurationError in next version
-        # todo: warn(
-        #   'settings.ST_RATELIMIT_CACHE cache's TIMEOUT '
-        #   'must be None (never expire) and it may '
-        #   'be other than the default. '
-        #   'To skip this check, set '
-        #   'settings.ST_RATELIMIT_SKIP_TIMEOUT_CHECK to True.')
-        pass
+        # todo: ConfigurationError in next version
+        warn(
+           'settings.ST_RATELIMIT_CACHE cache\'s TIMEOUT '
+           'must be None (never expire) and it may '
+           'be other than the default cache. '
+           'To skip this check, for example when using '
+           'a third-party backend with no TIMEOUT option, set '
+           'settings.ST_RATELIMIT_SKIP_TIMEOUT_CHECK to True. '
+           'This will raise an exception in next version.')
 
 
 class RateLimitError(Exception):

--- a/spirit/core/utils/ratelimit/ratelimit.py
+++ b/spirit/core/utils/ratelimit/ratelimit.py
@@ -14,6 +14,29 @@ TIME_DICT = {
     'm': 60}
 
 
+def validate_cache_config():
+    try:
+        cache = settings.CACHES[settings.ST_RATELIMIT_CACHE]
+    except KeyError:
+        # Django will raise later when using
+        # this cache so we do nothing
+        return
+
+    # Some third-party backend
+    # don't have a TIMEOUT option
+    if (not settings.ST_RATELIMIT_IGNORE_TIMEOUT_WARNING and
+            cache.get('TIMEOUT', 1) is not None):
+        # todo: raise ConfigurationError in next version
+        # todo: warn(
+        #   'settings.ST_RATELIMIT_CACHE cache's TIMEOUT '
+        #   'must be None (never expire) and it should '
+        #   'be other than the default. See spirit.settings. '
+        #   'To ignore this warning, set '
+        #   'settings.ST_RATELIMIT_IGNORE_TIMEOUT to True, '
+        #   'if you know what you are doing.')
+        pass
+
+
 class RateLimitError(Exception):
     """"""
 
@@ -21,6 +44,7 @@ class RateLimitError(Exception):
 class RateLimit:
 
     def __init__(self, request, uid, method=None, field=None, rate='5/5m'):
+        validate_cache_config()
         self.request = request
         self.uid = uid
         self.method = method or ['POST']

--- a/spirit/search/tests.py
+++ b/spirit/search/tests.py
@@ -3,7 +3,6 @@
 from __future__ import unicode_literals
 
 from django.test import TestCase
-from django.core.cache import cache
 from django.core.urlresolvers import reverse
 from django.template import Template, Context
 from django.conf import settings
@@ -28,7 +27,7 @@ HAYSTACK_TEST = {
 class SearchTopicIndexTest(TestCase):
 
     def setUp(self):
-        cache.clear()
+        utils.cache_clear()
 
     def test_index_queryset_excludes_private_topics(self):
         """
@@ -61,7 +60,7 @@ class SearchViewTest(TestCase):
         # self.connections = haystack.connections
         # haystack.connections = haystack.loading.ConnectionHandler(HAYSTACK_TEST)
 
-        cache.clear()
+        utils.cache_clear()
         self.user = utils.create_user()
         self.category = utils.create_category()
         self.topic = utils.create_topic(category=self.category, user=self.user, title="spirit search test foo")
@@ -123,7 +122,7 @@ class SearchViewTest(TestCase):
 class SearchFormTest(TestCase):
 
     def setUp(self):
-        cache.clear()
+        utils.cache_clear()
 
     def test_basic_search(self):
         data = {'q': 'foobar', }
@@ -149,7 +148,7 @@ class SearchFormTest(TestCase):
 class SearchTemplateTagTests(TestCase):
 
     def setUp(self):
-        cache.clear()
+        utils.cache_clear()
 
     def test_render_search_form(self):
         """

--- a/spirit/settings.py
+++ b/spirit/settings.py
@@ -11,7 +11,7 @@ ST_TOPIC_PRIVATE_CATEGORY_PK = 1
 ST_RATELIMIT_ENABLE = True
 ST_RATELIMIT_CACHE_PREFIX = 'srl'
 ST_RATELIMIT_CACHE = 'default'
-ST_RATELIMIT_IGNORE_TIMEOUT_WARNING = False
+ST_RATELIMIT_SKIP_TIMEOUT_CHECK = False
 
 ST_NOTIFICATIONS_PER_PAGE = 20
 
@@ -92,8 +92,10 @@ CACHES = {
 CACHES.update({
     'st_rate_limit': {
         'BACKEND': CACHES['default']['BACKEND'],
-        'LOCATION': CACHES['default']['LOCATION'],
-        'TIMEOUT': None}})
+        'LOCATION': 'spirit_rl_cache',
+        'TIMEOUT': None
+    }
+})
 
 AUTHENTICATION_BACKENDS = [
     'spirit.user.auth.backends.UsernameAuthBackend',

--- a/spirit/settings.py
+++ b/spirit/settings.py
@@ -11,6 +11,7 @@ ST_TOPIC_PRIVATE_CATEGORY_PK = 1
 ST_RATELIMIT_ENABLE = True
 ST_RATELIMIT_CACHE_PREFIX = 'srl'
 ST_RATELIMIT_CACHE = 'default'
+ST_RATELIMIT_IGNORE_TIMEOUT_WARNING = False
 
 ST_NOTIFICATIONS_PER_PAGE = 20
 
@@ -87,6 +88,12 @@ CACHES = {
         'LOCATION': 'spirit_cache',
     },
 }
+
+CACHES.update({
+    'st_rate_limit': {
+        'BACKEND': CACHES['default']['BACKEND'],
+        'LOCATION': CACHES['default']['LOCATION'],
+        'TIMEOUT': None}})
 
 AUTHENTICATION_BACKENDS = [
     'spirit.user.auth.backends.UsernameAuthBackend',

--- a/spirit/settings_tests.py
+++ b/spirit/settings_tests.py
@@ -42,6 +42,11 @@ CACHES.update({
     'default': {
         'BACKEND': 'django.core.cache.backends.locmem.LocMemCache',
     },
+    'st_rate_limit': {
+        'BACKEND': 'django.core.cache.backends.locmem.LocMemCache',
+        'LOCATION': 'spirit_rl_cache',
+        'TIMEOUT': None
+    }
 })
 
 # speedup tests requiring login
@@ -61,3 +66,5 @@ TEMPLATES[0]['OPTIONS']['loaders'] = [
 ]
 
 TEMPLATES[0]['OPTIONS']['debug'] = True
+
+ST_RATELIMIT_CACHE = 'st_rate_limit'

--- a/spirit/topic/favorite/tests.py
+++ b/spirit/topic/favorite/tests.py
@@ -4,7 +4,6 @@ from __future__ import unicode_literals
 
 from django.test import TestCase
 from django.core.urlresolvers import reverse
-from django.core.cache import cache
 
 from ...core.tests import utils
 from .models import TopicFavorite
@@ -15,7 +14,7 @@ class FavoriteViewTest(TestCase):
 
     # TODO: templatetags test
     def setUp(self):
-        cache.clear()
+        utils.cache_clear()
         self.user = utils.create_user()
         self.category = utils.create_category()
         self.topic = utils.create_topic(category=self.category, user=self.user)
@@ -81,7 +80,7 @@ class FavoriteViewTest(TestCase):
 class FavoriteFormTest(TestCase):
 
     def setUp(self):
-        cache.clear()
+        utils.cache_clear()
         self.user = utils.create_user()
         self.category = utils.create_category()
         self.topic = utils.create_topic(category=self.category, user=self.user)

--- a/spirit/topic/moderate/tests.py
+++ b/spirit/topic/moderate/tests.py
@@ -3,7 +3,6 @@
 from __future__ import unicode_literals
 
 from django.test import TestCase
-from django.core.cache import cache
 from django.core.urlresolvers import reverse
 
 from ...core.tests import utils
@@ -14,7 +13,7 @@ from ..models import Topic
 class TopicViewTest(TestCase):
 
     def setUp(self):
-        cache.clear()
+        utils.cache_clear()
         self.user = utils.create_user()
 
     def test_topic_moderate_delete(self):

--- a/spirit/topic/notification/tests.py
+++ b/spirit/topic/notification/tests.py
@@ -4,10 +4,9 @@ from __future__ import unicode_literals
 import json
 import datetime
 
-from django.test import TestCase, RequestFactory
+from django.test import TestCase
 from django.test.utils import override_settings
 from django.core.urlresolvers import reverse
-from django.core.cache import cache
 from django.template import Template, Context
 from django.utils import timezone
 
@@ -23,7 +22,7 @@ from .tags import render_notification_form, has_topic_notifications
 class TopicNotificationViewTest(TestCase):
 
     def setUp(self):
-        cache.clear()
+        utils.cache_clear()
         self.user = utils.create_user()
         self.user2 = utils.create_user()
         self.category = utils.create_category()
@@ -310,7 +309,7 @@ class TopicNotificationViewTest(TestCase):
 class TopicNotificationFormTest(TestCase):
 
     def setUp(self):
-        cache.clear()
+        utils.cache_clear()
         self.user = utils.create_user()
 
     def test_notification_creation(self):
@@ -355,7 +354,7 @@ class TopicNotificationFormTest(TestCase):
 class TopicNotificationModelsTest(TestCase):
 
     def setUp(self):
-        cache.clear()
+        utils.cache_clear()
         self.user = utils.create_user()
         self.user2 = utils.create_user()
         self.category = utils.create_category()
@@ -480,7 +479,7 @@ class TopicNotificationModelsTest(TestCase):
 class TopicNotificationTemplateTagsTest(TestCase):
 
     def setUp(self):
-        cache.clear()
+        utils.cache_clear()
         self.user = utils.create_user()
         self.category = utils.create_category()
         self.topic = utils.create_topic(self.category)

--- a/spirit/topic/poll/tests.py
+++ b/spirit/topic/poll/tests.py
@@ -4,7 +4,6 @@ from __future__ import unicode_literals
 
 from django.test import TestCase
 from django.core.urlresolvers import reverse
-from django.core.cache import cache
 from django.contrib.auth import get_user_model
 from django.template import Template, Context
 
@@ -20,7 +19,7 @@ User = get_user_model()
 class TopicPollViewTest(TestCase):
 
     def setUp(self):
-        cache.clear()
+        utils.cache_clear()
         self.user = utils.create_user()
         self.user2 = utils.create_user()
         self.category = utils.create_category()
@@ -208,7 +207,7 @@ class TopicPollViewTest(TestCase):
 class TopicPollFormTest(TestCase):
 
     def setUp(self):
-        cache.clear()
+        utils.cache_clear()
         self.user = utils.create_user()
         self.user2 = utils.create_user()
         self.category = utils.create_category()
@@ -294,7 +293,7 @@ class TopicPollFormTest(TestCase):
 class TopicPollVoteManyFormTest(TestCase):
 
     def setUp(self):
-        cache.clear()
+        utils.cache_clear()
         self.user = utils.create_user()
         self.user2 = utils.create_user()
         self.category = utils.create_category()
@@ -400,7 +399,7 @@ class TopicPollVoteManyFormTest(TestCase):
 class TopicPollSignalTest(TestCase):
 
     def setUp(self):
-        cache.clear()
+        utils.cache_clear()
         self.user = utils.create_user()
         self.category = utils.create_category()
         self.topic = utils.create_topic(category=self.category, user=self.user)
@@ -438,7 +437,7 @@ class TopicPollSignalTest(TestCase):
 class TopicPollTemplateTagsTest(TestCase):
 
     def setUp(self):
-        cache.clear()
+        utils.cache_clear()
         self.user = utils.create_user()
         self.category = utils.create_category()
         self.topic = utils.create_topic(category=self.category, user=self.user)

--- a/spirit/topic/private/tests.py
+++ b/spirit/topic/private/tests.py
@@ -4,7 +4,6 @@ from __future__ import unicode_literals
 import datetime
 
 from django.test import TestCase
-from django.core.cache import cache
 from django.core.urlresolvers import reverse
 from django.template import Template, Context
 from django.conf import settings
@@ -29,7 +28,7 @@ from . import views as private_views
 class TopicPrivateViewTest(TestCase):
 
     def setUp(self):
-        cache.clear()
+        utils.cache_clear()
         self.user = utils.create_user()
         self.user2 = utils.create_user()
 
@@ -393,7 +392,7 @@ class TopicPrivateViewTest(TestCase):
 class TopicPrivateFormTest(TestCase):
 
     def setUp(self):
-        cache.clear()
+        utils.cache_clear()
         self.user = utils.create_user()
         self.user2 = utils.create_user()
 
@@ -456,7 +455,7 @@ class TopicPrivateFormTest(TestCase):
 class TopicTemplateTagsTest(TestCase):
 
     def setUp(self):
-        cache.clear()
+        utils.cache_clear()
         self.user = utils.create_user()
         self.category = Category.objects.get(pk=settings.ST_TOPIC_PRIVATE_CATEGORY_PK)
         self.topic = utils.create_topic(category=self.category, user=self.user)
@@ -479,7 +478,7 @@ class TopicTemplateTagsTest(TestCase):
 class TopicPrivateUtilsTest(TestCase):
 
     def setUp(self):
-        cache.clear()
+        utils.cache_clear()
         self.user = utils.create_user()
         self.user2 = utils.create_user()
         self.category = utils.create_category()

--- a/spirit/topic/private/tests.py
+++ b/spirit/topic/private/tests.py
@@ -258,7 +258,7 @@ class TopicPrivateViewTest(TestCase):
         self.assertEqual(response.context['topics'][0].bookmark, bookmark)
 
     @override_djconfig(topics_per_page=1)
-    def test_private_list(self):
+    def test_private_list_paginated(self):
         """
         private topic list paginated
         """

--- a/spirit/topic/tests.py
+++ b/spirit/topic/tests.py
@@ -4,7 +4,6 @@ from __future__ import unicode_literals
 import datetime
 
 from django.test import TestCase, RequestFactory
-from django.core.cache import cache
 from django.core.urlresolvers import reverse
 from django.utils import timezone
 from django.core.exceptions import ObjectDoesNotExist
@@ -25,7 +24,7 @@ from .unread.models import TopicUnread
 class TopicViewTest(TestCase):
 
     def setUp(self):
-        cache.clear()
+        utils.cache_clear()
         self.user = utils.create_user()
 
     def test_topic_publish(self):
@@ -323,7 +322,7 @@ class TopicViewTest(TestCase):
 class TopicFormTest(TestCase):
 
     def setUp(self):
-        cache.clear()
+        utils.cache_clear()
         self.user = utils.create_user()
 
     def test_topic_publish(self):
@@ -375,7 +374,7 @@ class TopicFormTest(TestCase):
 class TopicUtilsTest(TestCase):
 
     def setUp(self):
-        cache.clear()
+        utils.cache_clear()
         self.user = utils.create_user()
 
     def test_topic_viewed(self):
@@ -403,7 +402,7 @@ class TopicUtilsTest(TestCase):
 class TopicModelsTest(TestCase):
 
     def setUp(self):
-        cache.clear()
+        utils.cache_clear()
         self.user = utils.create_user()
         self.category = utils.create_category()
         self.topic = utils.create_topic(category=self.category, user=self.user)

--- a/spirit/topic/unread/tests.py
+++ b/spirit/topic/unread/tests.py
@@ -2,8 +2,7 @@
 
 from __future__ import unicode_literals
 
-from django.core.cache import cache
-from django.test import TestCase, RequestFactory
+from django.test import TestCase
 from django.core.urlresolvers import reverse
 
 from ...core.tests import utils
@@ -14,7 +13,7 @@ from ...comment.bookmark.models import CommentBookmark
 class TopicUnreadViewTest(TestCase):
 
     def setUp(self):
-        cache.clear()
+        utils.cache_clear()
         self.user = utils.create_user()
         self.user2 = utils.create_user()
         self.category = utils.create_category()
@@ -125,7 +124,7 @@ class TopicUnreadViewTest(TestCase):
 class TopicUnreadModelsTest(TestCase):
 
     def setUp(self):
-        cache.clear()
+        utils.cache_clear()
         self.user = utils.create_user()
         self.user2 = utils.create_user()
         self.category = utils.create_category()

--- a/spirit/user/auth/tests/tests.py
+++ b/spirit/user/auth/tests/tests.py
@@ -4,7 +4,6 @@ from __future__ import unicode_literals
 
 from django.test import TestCase
 from django.core.urlresolvers import reverse
-from django.core.cache import cache
 from django.contrib.auth import get_user_model
 from django.core import mail
 from django.utils.translation import ugettext as _
@@ -24,7 +23,7 @@ User = get_user_model()
 class UserViewTest(TestCase):
 
     def setUp(self):
-        cache.clear()
+        utils.cache_clear()
         self.user = utils.create_user()
         self.user2 = utils.create_user()
         self.category = utils.create_category()
@@ -304,7 +303,7 @@ class UserViewTest(TestCase):
 class UserFormTest(TestCase):
 
     def setUp(self):
-        cache.clear()
+        utils.cache_clear()
         self.user = utils.create_user()
 
     def test_registration(self):
@@ -543,7 +542,7 @@ class UserFormTest(TestCase):
 class UserBackendTest(TestCase):
 
     def setUp(self):
-        cache.clear()
+        utils.cache_clear()
         self.user = utils.create_user(email="foobar@bar.com", password="bar")
 
     def test_email_auth_backend(self):

--- a/spirit/user/tests.py
+++ b/spirit/user/tests.py
@@ -5,7 +5,6 @@ import datetime
 
 from django.test import TestCase, RequestFactory
 from django.core.urlresolvers import reverse
-from django.core.cache import cache
 from django.contrib.auth import get_user_model, HASH_SESSION_KEY
 from django.core import mail
 from django.utils.translation import ugettext as _
@@ -30,7 +29,7 @@ User = get_user_model()
 class UserViewTest(TestCase):
 
     def setUp(self):
-        cache.clear()
+        utils.cache_clear()
         self.user = utils.create_user()
         self.user2 = utils.create_user()
         self.category = utils.create_category()
@@ -442,7 +441,7 @@ class UserViewTest(TestCase):
 class UserFormTest(TestCase):
 
     def setUp(self):
-        cache.clear()
+        utils.cache_clear()
         self.user = utils.create_user()
 
     def test_profile(self):
@@ -570,7 +569,7 @@ class UserFormTest(TestCase):
 class UserModelTest(TestCase):
 
     def setUp(self):
-        cache.clear()
+        utils.cache_clear()
 
     def test_user_superuser(self):
         """
@@ -597,7 +596,7 @@ class UserModelTest(TestCase):
 class UtilsUserTests(TestCase):
 
     def setUp(self):
-        cache.clear()
+        utils.cache_clear()
         self.user = utils.create_user()
 
     def test_user_activation_token_generator(self):


### PR DESCRIPTION
Fixes most of #120 

* Doesn't pass a timeout when creating the cache key
* Removes increment retry.
* Adds a new cache, set timeout to None, backend to `CACHE['default']['BACKEND']` and location to some other location
* Sets `ST_RATELIMIT_CACHE = 'st_rate_limit'` in example settings
* Adds deprecation warnings