### PR TITLE
Feature/search within comments

### DIFF
--- a/spirit/search/forms.py
+++ b/spirit/search/forms.py
@@ -20,8 +20,10 @@ class BaseSearchForm(SearchForm):
         q = self.cleaned_data['q']
 
         if len(q) < settings.ST_SEARCH_QUERY_MIN_LEN:
-            raise forms.ValidationError(_("Your search must contain at least %(length)s characters.")
-                                        % {'length': settings.ST_SEARCH_QUERY_MIN_LEN, })
+            raise forms.ValidationError(
+                _("Your search must contain at "
+                  "least %(length)s characters.") % {
+                    'length': settings.ST_SEARCH_QUERY_MIN_LEN})
 
         return q
 
@@ -35,19 +37,24 @@ class BasicSearchForm(BaseSearchForm):
             return sqs
 
         topics = sqs.models(Topic)
-        return topics.filter(is_removed=False, is_category_removed=False, is_subcategory_removed=False)
+        return topics.filter(
+            is_removed=False,
+            is_category_removed=False,
+            is_subcategory_removed=False)
 
 
 class AdvancedSearchForm(BaseSearchForm):
 
-    category = forms.ModelMultipleChoiceField(queryset=Category.objects.visible(),
-                                              required=False,
-                                              label=_('Filter by'),
-                                              widget=forms.CheckboxSelectMultiple)
+    category = forms.ModelMultipleChoiceField(
+        queryset=Category.objects.visible(),
+        required=False,
+        label=_('Filter by'),
+        widget=forms.CheckboxSelectMultiple)
 
     def __init__(self, *args, **kwargs):
         super(AdvancedSearchForm, self).__init__(*args, **kwargs)
-        self.fields['category'].label_from_instance = lambda obj: smart_text(obj.title)
+        self.fields['category'].label_from_instance = (
+            lambda obj: smart_text(obj.title))
 
     def search(self):
         sqs = super(AdvancedSearchForm, self).search()
@@ -59,6 +66,10 @@ class AdvancedSearchForm(BaseSearchForm):
         categories = self.cleaned_data['category']
 
         if categories:
-            topics = topics.filter(category_id__in=[c.pk for c in categories])
+            topics = topics.filter(
+                category_id__in=[c.pk for c in categories])
 
-        return topics.filter(is_removed=False, is_category_removed=False, is_subcategory_removed=False)
+        return topics.filter(
+            is_removed=False,
+            is_category_removed=False,
+            is_subcategory_removed=False)

--- a/spirit/search/forms.py
+++ b/spirit/search/forms.py
@@ -37,10 +37,7 @@ class BasicSearchForm(BaseSearchForm):
             return sqs
 
         topics = sqs.models(Topic)
-        return topics.filter(
-            is_removed=False,
-            is_category_removed=False,
-            is_subcategory_removed=False)
+        return topics.filter(is_removed=False)
 
 
 class AdvancedSearchForm(BaseSearchForm):
@@ -69,7 +66,4 @@ class AdvancedSearchForm(BaseSearchForm):
             topics = topics.filter(
                 category_id__in=[c.pk for c in categories])
 
-        return topics.filter(
-            is_removed=False,
-            is_category_removed=False,
-            is_subcategory_removed=False)
+        return topics.filter(is_removed=False)

--- a/spirit/search/search_indexes.py
+++ b/spirit/search/search_indexes.py
@@ -10,6 +10,10 @@ from ..topic.models import Topic
 
 
 # See: django-haystack issue #801
+# convert() from search engine
+# stored value to python value,
+# so it only matters when using
+# search_result.get_stored_fields()
 class BooleanField(indexes.BooleanField):
 
     bool_map = {'true': True, 'false': False}

--- a/spirit/search/search_indexes.py
+++ b/spirit/search/search_indexes.py
@@ -9,16 +9,32 @@ from haystack import indexes
 from ..topic.models import Topic
 
 
+# See: django-haystack issue #801
+class BooleanField(indexes.BooleanField):
+
+    bool_map = {'true': True, 'false': False}
+
+    def convert(self, value):
+        if value is None:
+            return None
+
+        if value in self.bool_map:
+            return self.bool_map[value]
+
+        return bool(value)
+
+
 class TopicIndex(indexes.SearchIndex, indexes.Indexable):
 
     text = indexes.CharField(document=True, use_template=True)
     category_id = indexes.IntegerField(model_attr='category_id')
-    is_removed = indexes.BooleanField()
+    is_removed = BooleanField()
 
     title = indexes.CharField(model_attr='title', indexed=False)
     slug = indexes.CharField(model_attr='slug', null=True, indexed=False)
-    main_category_name = indexes.CharField(indexed=False)
     comment_count = indexes.IntegerField(model_attr='comment_count', indexed=False)
+    last_active = indexes.DateTimeField(model_attr='last_active', indexed=False)
+    main_category_name = indexes.CharField(indexed=False)
 
     # Overridden
     def get_model(self):

--- a/spirit/search/search_indexes.py
+++ b/spirit/search/search_indexes.py
@@ -16,12 +16,16 @@ class TopicIndex(indexes.SearchIndex, indexes.Indexable):
     category_id = indexes.IntegerField(model_attr='category_id')
     is_removed = indexes.BooleanField(model_attr='is_removed')
     is_category_removed = indexes.BooleanField(model_attr='category__is_removed')
-    is_subcategory_removed = indexes.BooleanField(model_attr='category__parent__is_removed', default=False)
+    is_subcategory_removed = indexes.BooleanField(
+        model_attr='category__parent__is_removed',
+        default=False)
 
+    # Overridden
     def get_model(self):
         return Topic
 
+    # Overridden
     def index_queryset(self, using=None):
-        """Used when the entire index for model is updated."""
-        topics = super(TopicIndex, self).index_queryset(using=using)
-        return topics.exclude(category_id=settings.ST_TOPIC_PRIVATE_CATEGORY_PK)
+        return (self.get_model().objects
+                .all()
+                .exclude(category_id=settings.ST_TOPIC_PRIVATE_CATEGORY_PK))

--- a/spirit/search/search_indexes.py
+++ b/spirit/search/search_indexes.py
@@ -30,9 +30,9 @@ class BooleanField(indexes.BooleanField):
 
 class TopicIndex(indexes.SearchIndex, indexes.Indexable):
 
-    text = indexes.CharField(document=True, use_template=True)
-    category_id = indexes.IntegerField(model_attr='category_id')
-    is_removed = BooleanField()
+    text = indexes.CharField(document=True, use_template=True, stored=False)
+    category_id = indexes.IntegerField(model_attr='category_id', stored=False)
+    is_removed = BooleanField(stored=False)
 
     title = indexes.CharField(model_attr='title', indexed=False)
     slug = indexes.CharField(model_attr='slug', null=True, indexed=False)

--- a/spirit/search/search_indexes.py
+++ b/spirit/search/search_indexes.py
@@ -10,7 +10,7 @@ from ..topic.models import Topic
 
 
 # See: django-haystack issue #801
-# convert() from search engine
+# convert() from search-engine
 # stored value to python value,
 # so it only matters when using
 # search_result.get_stored_fields()
@@ -35,7 +35,7 @@ class TopicIndex(indexes.SearchIndex, indexes.Indexable):
     is_removed = BooleanField(stored=False)
 
     title = indexes.CharField(model_attr='title', indexed=False)
-    slug = indexes.CharField(model_attr='slug', null=True, indexed=False)
+    slug = indexes.CharField(model_attr='slug', indexed=False)
     comment_count = indexes.IntegerField(model_attr='comment_count', indexed=False)
     last_active = indexes.DateTimeField(model_attr='last_active', indexed=False)
     main_category_name = indexes.CharField(indexed=False)

--- a/spirit/search/search_indexes.py
+++ b/spirit/search/search_indexes.py
@@ -12,9 +12,13 @@ from ..topic.models import Topic
 class TopicIndex(indexes.SearchIndex, indexes.Indexable):
 
     text = indexes.CharField(document=True, use_template=True)
-    title = indexes.CharField(model_attr='title')
     category_id = indexes.IntegerField(model_attr='category_id')
     is_removed = indexes.BooleanField()
+
+    title = indexes.CharField(model_attr='title', indexed=False)
+    slug = indexes.CharField(model_attr='slug', null=True, indexed=False)
+    main_category_name = indexes.CharField(indexed=False)
+    comment_count = indexes.IntegerField(model_attr='comment_count', indexed=False)
 
     # Overridden
     def get_model(self):
@@ -24,17 +28,23 @@ class TopicIndex(indexes.SearchIndex, indexes.Indexable):
     def index_queryset(self, using=None):
         return (self.get_model().objects
                 .all()
-                .exclude(category_id=settings.ST_TOPIC_PRIVATE_CATEGORY_PK))
+                .exclude(category_id=settings.ST_TOPIC_PRIVATE_CATEGORY_PK)
+                .select_related('category__parent'))
 
     # Overridden
     def get_updated_field(self):
         """
+        This specify what topics should be indexed,\
+        based on the last time they were updated.
+
         Topics will be re-indexed when a new comment\
-        is added to the topic. To re-index deleted topics,\
+        is posted. To re-index deleted topics,\
         a full re-index must be ran.
 
         :return: Last updated name field
         """
+        # todo: override build_queryset, and filter by comment
+        # updated_at, topic.updated_at, category.updated_at
         return 'last_active'
 
     def prepare_is_removed(self, obj):
@@ -47,3 +57,13 @@ class TopicIndex(indexes.SearchIndex, indexes.Indexable):
         return (obj.is_removed or
                 obj.category.is_removed or
                 obj.main_category.is_removed)
+
+    def prepare_main_category_name(self, obj):
+        """
+        Populate the ``category_name`` index field\
+        with the main category name
+
+        :param obj: Topic
+        :return: main category name
+        """
+        return obj.main_category.title

--- a/spirit/search/search_indexes.py
+++ b/spirit/search/search_indexes.py
@@ -14,11 +14,7 @@ class TopicIndex(indexes.SearchIndex, indexes.Indexable):
     text = indexes.CharField(document=True, use_template=True)
     title = indexes.CharField(model_attr='title')
     category_id = indexes.IntegerField(model_attr='category_id')
-    is_removed = indexes.BooleanField(model_attr='is_removed')
-    is_category_removed = indexes.BooleanField(model_attr='category__is_removed')
-    is_subcategory_removed = indexes.BooleanField(
-        model_attr='category__parent__is_removed',
-        default=False)
+    is_removed = indexes.BooleanField()
 
     # Overridden
     def get_model(self):
@@ -29,3 +25,12 @@ class TopicIndex(indexes.SearchIndex, indexes.Indexable):
         return (self.get_model().objects
                 .all()
                 .exclude(category_id=settings.ST_TOPIC_PRIVATE_CATEGORY_PK))
+
+    # Overridden
+    def get_updated_field(self):
+        return None
+
+    def prepare_is_removed(self, obj):
+        return (obj.is_removed and
+                obj.category.is_removed and
+                obj.main_category.is_removed)

--- a/spirit/search/search_indexes.py
+++ b/spirit/search/search_indexes.py
@@ -28,9 +28,22 @@ class TopicIndex(indexes.SearchIndex, indexes.Indexable):
 
     # Overridden
     def get_updated_field(self):
-        return None
+        """
+        Topics will be re-indexed when a new comment\
+        is added to the topic. To re-index deleted topics,\
+        a full re-index must be ran.
+
+        :return: Last updated name field
+        """
+        return 'last_active'
 
     def prepare_is_removed(self, obj):
-        return (obj.is_removed and
-                obj.category.is_removed and
+        """
+        Populate the ``is_removed`` index field
+
+        :param obj: Topic
+        :return: whether the topic is removed or not
+        """
+        return (obj.is_removed or
+                obj.category.is_removed or
                 obj.main_category.is_removed)

--- a/spirit/search/tags.py
+++ b/spirit/search/tags.py
@@ -11,10 +11,3 @@ def render_search_form():
     form = BasicSearchForm()
     return {'form': form, }
 
-
-@register.assignment_tag()
-def get_topics_from_search_result(results):
-    # TODO: move to view
-    # Since Im only indexing Topics this is ok.
-    topics = [r.object for r in results]
-    return topics

--- a/spirit/search/templates/search/indexes/spirit_topic/topic_text.txt
+++ b/spirit/search/templates/search/indexes/spirit_topic/topic_text.txt
@@ -1,1 +1,4 @@
 {{ object.title }}
+{% for txt in object.get_all_comments_html %}
+{{ txt|striptags|safe }}
+{% endfor %}

--- a/spirit/search/templates/spirit/search/_render_list.html
+++ b/spirit/search/templates/spirit/search/_render_list.html
@@ -7,7 +7,7 @@
 
             <div class="row-title">
                 <a class="row-link" href="{% url 'spirit:topic:detail' pk=t.pk slug=t.fields.slug %}">
-                    {{ t.title }}
+                    {{ t.fields.title }}
                 </a>
             </div>
             <div class="row-info">

--- a/spirit/search/templates/spirit/search/_render_list.html
+++ b/spirit/search/templates/spirit/search/_render_list.html
@@ -1,0 +1,24 @@
+{% load spirit_tags i18n %}
+
+<div class="rows">
+
+    {% for t in topics %}
+        <div class="row">
+
+            <div class="row-title">
+                <a class="row-link" href="{% url 'spirit:topic:detail' pk=t.pk slug=t.fields.slug %}">
+                    {{ t.title }}
+                </a>
+            </div>
+            <div class="row-info">
+                <div>{{ t.fields.main_category_name }}</div><!--
+                 --><div><i class="fa fa-comment"></i> {{ t.fields.comment_count }}</div><!--
+                 --><div title="{{ t.fields.last_active }}">
+                        <i class="fa fa-clock-o"></i> {{ t.fields.last_active|shortnaturaltime }}
+                    </div>
+            </div>
+
+        </div>
+    {% endfor %}
+
+</div>

--- a/spirit/search/templates/spirit/search/search.html
+++ b/spirit/search/templates/spirit/search/search.html
@@ -18,7 +18,7 @@
         {% else %}
             <h1 class="headline">{% trans "Results" %}</h1>
 
-            {% if topics_page %}
+            {% if page %}
                 {% include "spirit/search/_render_list.html" with topics=page %}
                 {% render_paginator page %}
             {% else %}

--- a/spirit/search/templates/spirit/search/search.html
+++ b/spirit/search/templates/spirit/search/search.html
@@ -18,10 +18,8 @@
         {% else %}
             <h1 class="headline">{% trans "Results" %}</h1>
 
-            {% get_topics_from_search_result results=page as topics_page %}
-
             {% if topics_page %}
-                {% include "spirit/topic/_render_list.html" with topics=topics_page %}
+                {% include "spirit/search/_render_list.html" with topics=page %}
                 {% render_paginator page %}
             {% else %}
                 <p>{% trans "There are no search results." %}</p>

--- a/spirit/search/tests.py
+++ b/spirit/search/tests.py
@@ -63,8 +63,10 @@ class SearchViewTest(TestCase):
         utils.cache_clear()
         self.user = utils.create_user()
         self.category = utils.create_category()
-        self.topic = utils.create_topic(category=self.category, user=self.user, title="spirit search test foo")
-        self.topic2 = utils.create_topic(category=self.category, user=self.user, title="foo")
+        self.topic = utils.create_topic(
+            category=self.category, user=self.user, title="spirit search test foo")
+        self.topic2 = utils.create_topic(
+            category=self.category, user=self.user, title="foo")
 
         call_command("rebuild_index", verbosity=0, interactive=False)
 

--- a/spirit/search/tests.py
+++ b/spirit/search/tests.py
@@ -94,9 +94,6 @@ class SearchViewTest(TestCase):
             list(response.context['page']),
             [{
                 'fields': {
-                    'text': self.topic.title + '\n\n',
-                    'category_id': self.topic.category.pk,
-                    'is_removed': False,
                     'title': self.topic.title,
                     'slug': self.topic.slug,
                     'comment_count': self.topic.comment_count,
@@ -118,9 +115,6 @@ class SearchViewTest(TestCase):
             list(response.context['page']),
             [{
                 'fields': {
-                    'text': self.topic2.title + '\n\n',
-                    'category_id': self.topic2.category.pk,
-                    'is_removed': False,
                     'title': self.topic2.title,
                     'slug': self.topic2.slug,
                     'comment_count': self.topic2.comment_count,

--- a/spirit/search/tests.py
+++ b/spirit/search/tests.py
@@ -86,11 +86,23 @@ class SearchViewTest(TestCase):
         advanced search by topic
         """
         utils.login(self)
-        data = {'q': 'spirit search', }
-        response = self.client.get(reverse('spirit:search:search'),
-                                   data)
+        data = {'q': 'spirit search'}
+        response = self.client.get(
+            reverse('spirit:search:search'), data)
         self.assertEqual(response.status_code, 200)
-        self.assertEqual([s.object for s in response.context['page']], [self.topic, ])
+        self.assertEqual(
+            list(response.context['page']),
+            [{
+                'fields': {
+                    'text': self.topic.title + '\n\n',
+                    'category_id': self.topic.category.pk,
+                    'is_removed': False,
+                    'title': self.topic.title,
+                    'slug': self.topic.slug,
+                    'comment_count': self.topic.comment_count,
+                    'last_active': self.topic.last_active,
+                    'main_category_name': self.topic.main_category.title},
+                'pk': str(self.topic.pk)}])
 
     @override_djconfig(topics_per_page=1)
     def test_advanced_search_topics_paginate(self):
@@ -99,10 +111,22 @@ class SearchViewTest(TestCase):
         """
         utils.login(self)
         data = {'q': 'foo', }
-        response = self.client.get(reverse('spirit:search:search'),
-                                   data)
+        response = self.client.get(
+            reverse('spirit:search:search'), data)
         self.assertEqual(response.status_code, 200)
-        self.assertEqual([s.object for s in response.context['page']], [self.topic2, ])
+        self.assertEqual(
+            list(response.context['page']),
+            [{
+                'fields': {
+                    'text': self.topic2.title + '\n\n',
+                    'category_id': self.topic2.category.pk,
+                    'is_removed': False,
+                    'title': self.topic2.title,
+                    'slug': self.topic2.slug,
+                    'comment_count': self.topic2.comment_count,
+                    'last_active': self.topic2.last_active,
+                    'main_category_name': self.topic2.main_category.title},
+                'pk': str(self.topic2.pk)}])
 
     def test_advanced_search_in_category(self):
         """

--- a/spirit/search/urls.py
+++ b/spirit/search/urls.py
@@ -3,11 +3,10 @@
 from __future__ import unicode_literals
 
 from django.conf.urls import url
-from django.contrib.auth.decorators import login_required
 
 from . import views
 
 
 urlpatterns = [
-    url(r'^$', login_required(views.SearchView()), name='search'),
+    url(r'^$', views.SearchView(), name='search'),
 ]

--- a/spirit/search/urls.py
+++ b/spirit/search/urls.py
@@ -5,13 +5,9 @@ from __future__ import unicode_literals
 from django.conf.urls import url
 from django.contrib.auth.decorators import login_required
 
-from .forms import AdvancedSearchForm
 from . import views
 
 
 urlpatterns = [
-    url(r'^$', login_required(views.SearchView(
-        template='spirit/search/search.html',
-        form_class=AdvancedSearchForm)
-    ), name='search'),
+    url(r'^$', login_required(views.SearchView()), name='search'),
 ]

--- a/spirit/search/views.py
+++ b/spirit/search/views.py
@@ -5,6 +5,9 @@ from __future__ import unicode_literals
 from haystack.views import SearchView as BaseSearchView
 from djconfig import config
 
+from django.utils.decorators import method_decorator
+from django.contrib.auth.decorators import login_required
+
 from .forms import AdvancedSearchForm
 from ..core.utils.paginator import yt_paginate
 
@@ -24,6 +27,10 @@ class SearchView(BaseSearchView):
             template='spirit/search/search.html',
             form_class=AdvancedSearchForm,
             load_all=False)
+
+    @method_decorator(login_required)
+    def __call__(self, request):
+        return super(SearchView, self).__call__(request)
 
     def build_page(self):
         paginator = None

--- a/spirit/search/views.py
+++ b/spirit/search/views.py
@@ -5,16 +5,30 @@ from __future__ import unicode_literals
 from haystack.views import SearchView as BaseSearchView
 from djconfig import config
 
+from .forms import AdvancedSearchForm
 from ..core.utils.paginator import yt_paginate
 
 
 class SearchView(BaseSearchView):
+    """
+    This view does not pre load data fom\
+    the database (``load_all=False``),\
+    all required fields to display the\
+    results must be stored (ie: ``indexed=False``).
+
+    Avoid doing ``{{ result.object }}`` to\
+    prevent database hits.
+    """
+    def __init__(self, *_args, **_kwargs):  # no-qa
+        super(SearchView, self).__init__(
+            template='spirit/search/search.html',
+            form_class=AdvancedSearchForm,
+            load_all=False)
 
     def build_page(self):
         paginator = None
         page = yt_paginate(
             self.results,
             per_page=config.topics_per_page,
-            page_number=self.request.GET.get('page', 1)
-        )
+            page_number=self.request.GET.get('page', 1))
         return paginator, page

--- a/spirit/search/views.py
+++ b/spirit/search/views.py
@@ -19,7 +19,7 @@ class SearchView(BaseSearchView):
     Avoid doing ``{{ result.object }}`` to\
     prevent database hits.
     """
-    def __init__(self, *_args, **_kwargs):  # no-qa
+    def __init__(self, *args, **kwargs):  # no-qa
         super(SearchView, self).__init__(
             template='spirit/search/search.html',
             form_class=AdvancedSearchForm,

--- a/spirit/search/views.py
+++ b/spirit/search/views.py
@@ -31,4 +31,7 @@ class SearchView(BaseSearchView):
             self.results,
             per_page=config.topics_per_page,
             page_number=self.request.GET.get('page', 1))
+        page = [
+            {'fields': r.get_stored_fields(), 'pk': r.pk}
+            for r in page]
         return paginator, page

--- a/spirit/topic/models.py
+++ b/spirit/topic/models.py
@@ -100,3 +100,11 @@ class Topic(models.Model):
         Topic.objects\
             .filter(pk=self.pk)\
             .update(comment_count=F('comment_count') - 1)
+
+    def get_all_comments_html(self):
+        """
+        For search indexing
+
+        :return: List of comments in HTML
+        """
+        return self.comment_set.values_list('comment_html', flat=True)


### PR DESCRIPTION
Fixes #57 

Changes:
* Avoids hitting the database entirely
* Fetches all comments content for searching
* Avoids updating everything when doing a partial re-index

Caveats:

There seems to be no way to fetch comments with offset/limit since all the content must be part of the document, there is no way to add more content to an existing document.

It won't update category titles, topic titles, or removed status when doing a partial re-index. Currently it only adds new comments. I'll work on improving this on following PRs.