### PR TITLE
Fix Boolean filters for Elasticsearch

### DIFF
--- a/spirit/search/forms.py
+++ b/spirit/search/forms.py
@@ -37,7 +37,7 @@ class BasicSearchForm(BaseSearchForm):
             return sqs
 
         topics = sqs.models(Topic)
-        return topics.filter(is_removed=False)
+        return topics.filter(is_removed=0)
 
 
 class AdvancedSearchForm(BaseSearchForm):
@@ -66,4 +66,4 @@ class AdvancedSearchForm(BaseSearchForm):
             topics = topics.filter(
                 category_id__in=[c.pk for c in categories])
 
-        return topics.filter(is_removed=False)
+        return topics.filter(is_removed=0)


### PR DESCRIPTION
Elasticsearch backend in Haystack doesn't convert Python Boolean False to the `'false'` string, as stored in the index, but a filter of 0 (zero) is translated to 'false' in Whoosh and Elasticsearch.

Tested working on Heroku with Searchbox.