### PR TITLE
Python 2 unicode compatible

### DIFF
--- a/spirit/category/models.py
+++ b/spirit/category/models.py
@@ -3,15 +3,18 @@
 from __future__ import unicode_literals
 
 from django.db import models
-from django.utils.translation import ugettext_lazy as _
+
 from django.core.urlresolvers import reverse
 from django.conf import settings
+from django.utils.encoding import python_2_unicode_compatible
+from django.utils.translation import ugettext_lazy as _
 from django.utils import timezone
 
 from .managers import CategoryQuerySet
 from ..core.utils.models import AutoSlugField
 
 
+@python_2_unicode_compatible
 class Category(models.Model):
     """
     Category model
@@ -43,6 +46,9 @@ class Category(models.Model):
         ordering = ['title', 'pk']
         verbose_name = _("category")
         verbose_name_plural = _("categories")
+
+    def __str__(self):
+        return self.title
 
     def get_absolute_url(self):
         if self.pk == settings.ST_TOPIC_PRIVATE_CATEGORY_PK:

--- a/spirit/category/tests.py
+++ b/spirit/category/tests.py
@@ -152,6 +152,10 @@ class CategoryModelTest(TestCase):
     def setUp(self):
         utils.cache_clear()
 
+    def test_str(self):
+        category = utils.create_category()
+        self.assertEqual(category.__str__(), category.title)
+
     def test_is_subcategory(self):
         """
         Should return whether the category\

--- a/spirit/comment/models.py
+++ b/spirit/comment/models.py
@@ -50,9 +50,11 @@ class Comment(models.Model):
         verbose_name_plural = _("comments")
 
     def __str__(self):
-        return _('%s by %s at %s') % (
-            self.get_action_display(), self.user, self.date
-        )
+        return _('%(action)s by %(user)s at %(date)s') % {
+            'action': self.get_action_display(),
+            'user': self.user,
+            'date': self.date,
+        }
 
     def get_absolute_url(self):
         return reverse('spirit:comment:find', kwargs={'pk': str(self.id), })

--- a/spirit/comment/models.py
+++ b/spirit/comment/models.py
@@ -51,7 +51,7 @@ class Comment(models.Model):
 
     def __str__(self):
         return _('%s by %s at %s') % (
-            self.get_action_display().ucfirst(), self.user, self.date
+            self.get_action_display(), self.user, self.date
         )
 
     def get_absolute_url(self):

--- a/spirit/comment/models.py
+++ b/spirit/comment/models.py
@@ -3,10 +3,11 @@
 from __future__ import unicode_literals
 
 from django.db import models
-from django.utils.translation import ugettext_lazy as _
 from django.core.urlresolvers import reverse
 from django.conf import settings
 from django.db.models import F
+from django.utils.encoding import python_2_unicode_compatible
+from django.utils.translation import ugettext_lazy as _
 from django.utils import timezone
 
 from .managers import CommentQuerySet
@@ -24,6 +25,7 @@ ACTION = (
 )
 
 
+@python_2_unicode_compatible
 class Comment(models.Model):
 
     user = models.ForeignKey(settings.AUTH_USER_MODEL, related_name='st_comments')
@@ -46,6 +48,11 @@ class Comment(models.Model):
         ordering = ['-date', '-pk']
         verbose_name = _("comment")
         verbose_name_plural = _("comments")
+
+    def __str__(self):
+        return _('%s by %s at %s') % (
+            self.get_action_display().ucfirst(), self.user, self.date
+        )
 
     def get_absolute_url(self):
         return reverse('spirit:comment:find', kwargs={'pk': str(self.id), })

--- a/spirit/comment/tests.py
+++ b/spirit/comment/tests.py
@@ -431,7 +431,7 @@ class CommentViewTest(TestCase):
                                     data=files)
         res = json.loads(response.content.decode('utf-8'))
         image_url = os.path.join(
-            settings.MEDIA_URL, 'spirit', 'images', str(self.user.pk),  "bf21c3043d749d5598366c26e7e4ab44.gif"
+            settings.MEDIA_URL, 'spirit', 'images', str(self.user.pk), "bf21c3043d749d5598366c26e7e4ab44.gif"
         ).replace("\\", "/")
         self.assertEqual(res['url'], image_url)
         image_path = os.path.join(
@@ -464,6 +464,10 @@ class CommentModelsTest(TestCase):
         self.user = utils.create_user()
         self.category = utils.create_category()
         self.topic = utils.create_topic(category=self.category, user=self.user)
+
+    def test_str(self):
+        comment = utils.create_comment(topic=self.topic)
+        self.assertTrue(comment.__str__())
 
     def test_comment_increase_modified_count(self):
         """

--- a/spirit/topic/models.py
+++ b/spirit/topic/models.py
@@ -3,9 +3,11 @@
 from __future__ import unicode_literals
 
 from django.db import models
-from django.utils.translation import ugettext_lazy as _
+
 from django.core.urlresolvers import reverse
 from django.conf import settings
+from django.utils.encoding import python_2_unicode_compatible
+from django.utils.translation import ugettext_lazy as _
 from django.utils import timezone
 from django.db.models import F
 
@@ -13,6 +15,7 @@ from .managers import TopicQuerySet
 from ..core.utils.models import AutoSlugField
 
 
+@python_2_unicode_compatible
 class Topic(models.Model):
     """
     Topic model
@@ -48,6 +51,9 @@ class Topic(models.Model):
         ordering = ['-last_active', '-pk']
         verbose_name = _("topic")
         verbose_name_plural = _("topics")
+
+    def __str__(self):
+        return self.title
 
     def get_absolute_url(self):
         if self.category_id == settings.ST_TOPIC_PRIVATE_CATEGORY_PK:

--- a/spirit/topic/tests.py
+++ b/spirit/topic/tests.py
@@ -7,7 +7,6 @@ import hashlib
 from django.test import TestCase, RequestFactory, override_settings
 from django.core.urlresolvers import reverse
 from django.utils import timezone
-from django.core.exceptions import ObjectDoesNotExist
 
 from djconfig.utils import override_djconfig
 
@@ -548,6 +547,9 @@ class TopicModelsTest(TestCase):
         self.user = utils.create_user()
         self.category = utils.create_category()
         self.topic = utils.create_topic(category=self.category, user=self.user)
+
+    def test_str(self):
+        self.assertEqual(self.topic.__str__(), self.topic.title)
 
     def test_topic_increase_view_count(self):
         """

--- a/spirit/user/models.py
+++ b/spirit/user/models.py
@@ -5,6 +5,7 @@ from datetime import timedelta
 
 from django.db import models
 from django.core.urlresolvers import reverse
+from django.utils.encoding import python_2_unicode_compatible
 from django.utils.translation import ugettext_lazy as _
 from django.utils import timezone
 from django.conf import settings
@@ -12,6 +13,7 @@ from django.conf import settings
 from ..core.utils.models import AutoSlugField
 
 
+@python_2_unicode_compatible
 class UserProfile(models.Model):
     user = models.OneToOneField(settings.AUTH_USER_MODEL, verbose_name=_("profile"), related_name='st')
 
@@ -36,6 +38,9 @@ class UserProfile(models.Model):
     class Meta:
         verbose_name = _("forum profile")
         verbose_name_plural = _("forum profiles")
+
+    def __str__(self):
+        return _('Forum profile for %s') % self.user
 
     def save(self, *args, **kwargs):
         if self.user.is_superuser:

--- a/spirit/user/tests.py
+++ b/spirit/user/tests.py
@@ -601,6 +601,11 @@ class UserModelTest(TestCase):
     def setUp(self):
         utils.cache_clear()
 
+    def test_str(self):
+        user = User()
+        user.save()
+        self.assertEquals(user.st.__str__(), 'Forum profile for %s' % user)
+
     def test_user_superuser(self):
         """
         is_superuser should always be is_administrator and is_moderator


### PR DESCRIPTION
Adds `python_2_unicode_compatible` decorator and `__str__()` methods to the most common models to help with integration into other admin interfaces when integrating as an app into an existing site (in my case, Wagtail)