### PR TITLE
markdown merge block link rules

### DIFF
--- a/spirit/core/tests/tests_markdown.py
+++ b/spirit/core/tests/tests_markdown.py
@@ -197,7 +197,7 @@ class UtilsMarkdownTests(TestCase):
             "https://www.youtube.com/embed/vsF0K3Ou1v0\n"
             "https://www.youtube.com/watch?v=<bad>\n"
             "https://www.noyoutube.com/watch?v=Z0UISCEe52Y\n"
-            "badbad https://www.youtube.com/watch?v=Z0UISCEe52Y\n"
+            "badbad https://www.youtube.com/watch?v=Z0UISCEe52Y\n\n"
             "https://www.youtube.com/watch?v=Z0UISCEe52Y badbad\n"
         )
         comment_md = Markdown().render(comment)
@@ -220,13 +220,13 @@ class UtilsMarkdownTests(TestCase):
                 'allowfullscreen></iframe></span>',
                 '<span class="video"><iframe src="https://www.youtube.com/embed/vsF0K3Ou1v0?html5=1"'
                 ' allowfullscreen></iframe></span>',
-                '<p><a rel="nofollow" href="https://www.youtube.com/watch?v=">'
-                'https://www.youtube.com/watch?v=</a>&lt;bad&gt;<br>',  # smart_amp ain't smart
-                '<a rel="nofollow" href="https://www.noyoutube.com/watch?v=Z0UISCEe52Y">'
-                'https://www.noyoutube.com/watch?v=Z0UISCEe52Y</a><br>',
-                'badbad <a rel="nofollow" href="https://www.youtube.com/watch?v=Z0UISCEe52Y">'
-                'https://www.youtube.com/watch?v=Z0UISCEe52Y</a><br>',
-                '<a rel="nofollow" href="https://www.youtube.com/watch?v=Z0UISCEe52Y">'
+                '<p><a rel="nofollow" href="https://www.youtube.com/watch?v=&lt;bad&gt;">'
+                'https://www.youtube.com/watch?v=&lt;bad&gt;</a></p>',
+                '<p><a rel="nofollow" href="https://www.noyoutube.com/watch?v=Z0UISCEe52Y">'
+                'https://www.noyoutube.com/watch?v=Z0UISCEe52Y</a></p>',
+                '<p>badbad <a rel="nofollow" href="https://www.youtube.com/watch?v=Z0UISCEe52Y">'
+                'https://www.youtube.com/watch?v=Z0UISCEe52Y</a></p>',
+                '<p><a rel="nofollow" href="https://www.youtube.com/watch?v=Z0UISCEe52Y">'
                 'https://www.youtube.com/watch?v=Z0UISCEe52Y</a> badbad</p>'
             ]
         )
@@ -244,7 +244,7 @@ class UtilsMarkdownTests(TestCase):
             "https://vimeo.com/album/2222222/video/11111111\n"
             "https://vimeo.com/11111111?param=value\n"
             "https://novimeo.com/11111111\n"
-            "bad https://novimeo.com/11111111\n"
+            "bad https://novimeo.com/11111111\n\n"
             "https://novimeo.com/11111111 bad"
         )
         comment_md = Markdown().render(comment)
@@ -266,9 +266,9 @@ class UtilsMarkdownTests(TestCase):
                 '<span class="video"><iframe src="https://player.vimeo.com/video/11111111" '
                 'allowfullscreen></iframe></span>',
 
-                '<p><a rel="nofollow" href="https://novimeo.com/11111111">https://novimeo.com/11111111</a><br>',
-                'bad <a rel="nofollow" href="https://novimeo.com/11111111">https://novimeo.com/11111111</a><br>',
-                '<a rel="nofollow" href="https://novimeo.com/11111111">https://novimeo.com/11111111</a> bad</p>'
+                '<p><a rel="nofollow" href="https://novimeo.com/11111111">https://novimeo.com/11111111</a></p>',
+                '<p>bad <a rel="nofollow" href="https://novimeo.com/11111111">https://novimeo.com/11111111</a></p>',
+                '<p><a rel="nofollow" href="https://novimeo.com/11111111">https://novimeo.com/11111111</a> bad</p>'
             ]
         )
 
@@ -776,9 +776,9 @@ class UtilsMarkdownTests(TestCase):
         self.assertEqual(
             comment_md.splitlines(),
             [
-                '<p><a rel="nofollow" href="http://foo.com">http://foo.com</a><br>',
-                '<a rel="nofollow" href="http://foo.com?foo=1&amp;bar=2">http://foo.com?foo=1&amp;bar=2</a><br>',
-                '<a rel="nofollow" href="http://foo.com/">http://foo.com/</a>&lt;bad&gt;</p>'
+                '<p><a rel="nofollow" href="http://foo.com">http://foo.com</a></p>',
+                '<p><a rel="nofollow" href="http://foo.com?foo=1&amp;bar=2">http://foo.com?foo=1&amp;bar=2</a></p>',
+                '<p><a rel="nofollow" href="http://foo.com/&lt;bad&gt;">http://foo.com/&lt;bad&gt;</a></p>'
             ])
 
     def test_autolink_without_no_follow(self):

--- a/spirit/core/utils/markdown/block.py
+++ b/spirit/core/utils/markdown/block.py
@@ -17,36 +17,21 @@ class BlockGrammar(mistune.BlockGrammar):
         r'(?:\n+|$)'
     )
 
-    # This is used their own matching rule,
+    # These used to be their own matching rule,
     # but matching once instead of X times is way faster
-    #
-    # youtube_link
-    #
-    # Try to get the video ID. Works for URLs of the form:
-    # * https://www.youtube.com/watch?v=Z0UISCEe52Y
-    # * http://youtu.be/afyK1HSFfgw
-    # * https://www.youtube.com/embed/vsF0K3Ou1v0
-    #
-    # Also works for timestamps:
-    # * https://www.youtube.com/watch?v=Z0UISCEe52Y&t=1m30s
-    # * https://www.youtube.com/watch?v=O1QQajfobPw&t=1h1m38s
-    # * https://www.youtube.com/watch?v=O1QQajfobPw&feature=youtu.be&t=3698
-    # * https://youtu.be/O1QQajfobPw?t=3698
-    # * https://youtu.be/O1QQajfobPw?t=1h1m38s
-    #
-    # vimeo_link
-    #
-    # Try to get the video ID. Works for URLs of the form:
-    # * https://vimeo.com/11111111
-    # * https://www.vimeo.com/11111111
-    # * https://player.vimeo.com/video/11111111
-    # * https://vimeo.com/channels/11111111
-    # * https://vimeo.com/groups/name/videos/11111111
-    # * https://vimeo.com/album/2222222/video/11111111
-    # * https://vimeo.com/11111111?param=value
-    #
     sub_block_link = re.compile(
         r'(?:'
+            # Try to get the video ID. Works for URLs of the form:
+            # * https://www.youtube.com/watch?v=Z0UISCEe52Y
+            # * http://youtu.be/afyK1HSFfgw
+            # * https://www.youtube.com/embed/vsF0K3Ou1v0
+            #
+            # Also works for timestamps:
+            # * https://www.youtube.com/watch?v=Z0UISCEe52Y&t=1m30s
+            # * https://www.youtube.com/watch?v=O1QQajfobPw&t=1h1m38s
+            # * https://www.youtube.com/watch?v=O1QQajfobPw&feature=youtu.be&t=3698
+            # * https://youtu.be/O1QQajfobPw?t=3698
+            # * https://youtu.be/O1QQajfobPw?t=1h1m38s
             r'(?P<youtube_link>'
                 r'^https?://(?:www\.)?'
                 r'(?:youtube\.com/watch\?v='
@@ -61,6 +46,14 @@ class BlockGrammar(mistune.BlockGrammar):
                 r')){,10}'
                 r'(?:\n+|$)'
             r')|'
+            # Try to get the video ID. Works for URLs of the form:
+            # * https://vimeo.com/11111111
+            # * https://www.vimeo.com/11111111
+            # * https://player.vimeo.com/video/11111111
+            # * https://vimeo.com/channels/11111111
+            # * https://vimeo.com/groups/name/videos/11111111
+            # * https://vimeo.com/album/2222222/video/11111111
+            # * https://vimeo.com/11111111?param=value
             r'(?P<vimeo_link>'
                 r'^https?://(?:www\.|player\.)?'
                 r'vimeo\.com/'
@@ -69,6 +62,18 @@ class BlockGrammar(mistune.BlockGrammar):
                 r'|album/(?:\d+)/video/'
                 r'|video/)?'
                 r'(?P<vimeo_id>\d+)'
+                r'(?:\?[^\s]+)?'
+                r'(?:\n+|$)'
+            r')|'
+            # Try to get the video ID. Works for URLs of the form:
+            # * https://gfycat.com/videoid
+            # * https://www.gfycat.com/videoid
+            # * http://gfycat.com/videoid
+            # * http://www.gfycat.com/videoid
+            r'(?P<gfycat_link>'
+                r'^https?://(?:www\.)?'
+                r'gfycat\.com/'
+                r'(?P<gfycat_id>\w+)'
                 r'(?:\?[^\s]+)?'
                 r'(?:\n+|$)'
             r')|'
@@ -89,19 +94,6 @@ class BlockGrammar(mistune.BlockGrammar):
                 r'(?:\n+|$)'
             r')'
         r')'
-    )
-
-    # Try to get the video ID. Works for URLs of the form:
-    # * https://gfycat.com/videoid
-    # * https://www.gfycat.com/videoid
-    # * http://gfycat.com/videoid
-    # * http://www.gfycat.com/videoid
-    gfycat = re.compile(
-        r'^https?://(www\.)?'
-        r'gfycat\.com/'
-        r'(?P<id>\w+)'
-        r'(\?[^\s]+)?'
-        r'(?:\n+|$)'
     )
 
     # Capture polls:
@@ -130,7 +122,6 @@ class BlockLexer(mistune.BlockLexer):
 
     default_rules = copy.copy(mistune.BlockLexer.default_rules)
     default_rules.insert(0, 'block_link')
-    default_rules.insert(0, 'gfycat')
     default_rules.insert(0, 'poll')
 
     _sub_block_links = (
@@ -139,6 +130,7 @@ class BlockLexer(mistune.BlockLexer):
         'video_link',
         'youtube_link',
         'vimeo_link',
+        'gfycat_link'
     )
 
     def __init__(self, rules=None, **kwargs):
@@ -208,10 +200,10 @@ class BlockLexer(mistune.BlockLexer):
             'video_id': m.group("vimeo_id")
         })
 
-    def parse_gfycat(self, m):
+    def parse_gfycat_link(self, m):
         self.tokens.append({
-            'type': 'gfycat',
-            'video_id': m.group("id")
+            'type': 'gfycat_link',
+            'video_id': m.group("gfycat_id")
         })
 
     def parse_poll(self, m):

--- a/spirit/core/utils/markdown/markdown.py
+++ b/spirit/core/utils/markdown/markdown.py
@@ -71,8 +71,10 @@ class Markdown(mistune.Markdown):
             video_id=self.token['video_id']
         )
 
-    def output_gfycat(self):
-        return self.renderer.gfycat(video_id=self.token['video_id'])
+    def output_gfycat_link(self):
+        return self.renderer.gfycat_link(
+            video_id=self.token['video_id']
+        )
 
     def output_poll(self):
         try:

--- a/spirit/core/utils/markdown/markdown.py
+++ b/spirit/core/utils/markdown/markdown.py
@@ -38,23 +38,38 @@ class Markdown(mistune.Markdown):
     def get_polls(self):
         return self.block.polls
 
+    def output_block_link(self):
+        return self.renderer.block_link(
+            link=self.token['link'])
+
     def output_audio_link(self):
-        return self.renderer.audio_link(link=self.token['link'])
+        return self.renderer.audio_link(
+            link=self.token['link'])
 
     def output_image_link(self):
-        return self.renderer.image_link(src=self.token['src'], title=self.token['title'], text=self.token['text'])
+        return self.renderer.image_link(
+            src=self.token['src'],
+            title=self.token['title'],
+            text=self.token['text']
+        )
 
     def output_video_link(self):
-        return self.renderer.video_link(link=self.token['link'])
+        return self.renderer.video_link(
+            link=self.token['link']
+        )
 
-    def output_youtube(self):
-        return self.renderer.youtube(video_id=self.token['video_id'],
-                                     start_hours=self.token['start_hours'],
-                                     start_minutes=self.token['start_minutes'],
-                                     start_seconds=self.token['start_seconds'])
+    def output_youtube_link(self):
+        return self.renderer.youtube_link(
+            video_id=self.token['video_id'],
+            start_hours=self.token['start_hours'],
+            start_minutes=self.token['start_minutes'],
+            start_seconds=self.token['start_seconds']
+        )
 
-    def output_vimeo(self):
-        return self.renderer.vimeo(video_id=self.token['video_id'])
+    def output_vimeo_link(self):
+        return self.renderer.vimeo_link(
+            video_id=self.token['video_id']
+        )
 
     def output_gfycat(self):
         return self.renderer.gfycat(video_id=self.token['video_id'])
@@ -63,6 +78,8 @@ class Markdown(mistune.Markdown):
         try:
             name = self.token['name']
         except KeyError:
-            return self.renderer.poll_raw(poll_txt=self.token['raw'])
+            return self.renderer.poll_raw(
+                poll_txt=self.token['raw']
+            )
         else:
             return self.renderer.poll(name=name)

--- a/spirit/core/utils/markdown/renderer.py
+++ b/spirit/core/utils/markdown/renderer.py
@@ -148,9 +148,11 @@ class Renderer(mistune.Renderer):
             'allowfullscreen></iframe></span>\n'
             .format(video_id=video_id))
 
-    def gfycat(self, video_id):
-        return '<span class="video"><iframe src="https://gfycat.com/ifr/{video_id}" ' \
-               'frameborder="0" scrolling="no" allowfullscreen></iframe></span>\n'.format(video_id=video_id)
+    def gfycat_link(self, video_id):
+        return (
+            '<span class="video"><iframe src="https://gfycat.com/ifr/{video_id}" '
+            'frameborder="0" scrolling="no" allowfullscreen></iframe></span>\n'
+            .format(video_id=video_id))
 
     def poll(self, name):
         return '<poll name={name}>\n'.format(name=name)

--- a/spirit/core/utils/markdown/renderer.py
+++ b/spirit/core/utils/markdown/renderer.py
@@ -42,14 +42,18 @@ class Renderer(mistune.Renderer):
 
         if not title:
             if self.options['no_follow']:
-                return '<a rel="nofollow" href="%s">%s</a>' % (link, text)
+                return (
+                    '<a rel="nofollow" href="%s">%s</a>'
+                    % (link, text))
 
             return '<a href="%s">%s</a>' % (link, text)
 
         title = escape(title)
 
         if self.options['no_follow']:
-            return '<a rel="nofollow" href="%s" title="%s">%s</a>' % (link, title, text)
+            return (
+                '<a rel="nofollow" href="%s" title="%s">%s</a>'
+                % (link, title, text))
 
         return '<a href="%s" title="%s">%s</a>' % (link, title, text)
 
@@ -69,48 +73,80 @@ class Renderer(mistune.Renderer):
 
         return '%s>' % html
 
+    def emoji(self, name_class, name_raw):
+        return (
+            '<i class="tw tw-{name_class}" '
+            'title=":{name_raw}:"></i>'
+            .format(
+                name_class=name_class,
+                name_raw=name_raw))
+
+    def mention(self, username, url):
+        return (
+            '<a class="comment-mention" rel="nofollow" '
+            'href="{url}">@{username}</a>'
+            .format(
+                username=username,
+                url=url))
+
+    def block_link(self, link):
+        return '<p>%s</p>\n' % self.autolink(link)
+
     def audio_link(self, link):
         link = sanitize_url(link)
-        return '<audio controls><source src="{link}">' \
-               '<a rel="nofollow" href="{link}">{link}</a></audio>\n'.format(link=link)
+        return (
+            '<audio controls><source src="{link}">'
+            '<a rel="nofollow" href="{link}">'
+            '{link}</a></audio>\n'
+            .format(link=link))
 
     def image_link(self, src, title, text):
         image = self.image(src, title, text)
         return '<p>{image}</p>\n'.format(image=image)
 
-    def emoji(self, name_class, name_raw):
-        # todo: add no-follow to links since we are going to need migration to fix emojis
-        return '<i class="tw tw-{name_class}" title=":{name_raw}:"></i>'.format(
-            name_class=name_class,
-            name_raw=name_raw
-        )
-
-    def mention(self, username, url):
-        return '<a class="comment-mention" rel="nofollow" href="{url}">@{username}</a>'.format(
-            username=username,
-            url=url
-        )
-
     def video_link(self, link):
         link = sanitize_url(link)
-        return '<video controls><source src="{link}">' \
-               '<a rel="nofollow" href="{link}">{link}</a></video>\n'.format(link=link)
+        return (
+            '<video controls><source src="{link}">'
+            '<a rel="nofollow" href="{link}">{link}</a></video>\n'
+            .format(link=link))
 
-    def youtube(self, video_id, start_hours=None, start_minutes=None, start_seconds=None):
+    def youtube_link(
+            self,
+            video_id,
+            start_hours=None,
+            start_minutes=None,
+            start_seconds=None):
         timestamp = 0
+
         if start_hours:
             timestamp += int(start_hours.replace('h', '')) * 60 * 60
+
         if start_minutes:
             timestamp += int(start_minutes.replace('m', '')) * 60
+
         if start_seconds:
             timestamp += int(start_seconds.replace('s', ''))
-        timestamp = ('&start=%s' % timestamp) if timestamp else ''
-        return '<span class="video"><iframe src="https://www.youtube.com/embed/{video_id}?html5=1{timestamp}" ' \
-               'allowfullscreen></iframe></span>\n'.format(video_id=video_id, timestamp=timestamp)
 
-    def vimeo(self, video_id):
-        return '<span class="video"><iframe src="https://player.vimeo.com/video/{video_id}" ' \
-               'allowfullscreen></iframe></span>\n'.format(video_id=video_id)
+        if timestamp:
+            timestamp = '&start=%s' % timestamp
+        else:
+            timestamp = ''
+
+        return (
+            '<span class="video"><iframe '
+            'src="https://www.youtube.com/embed/{video_id}?html5=1{timestamp}" '
+            'allowfullscreen></iframe></span>\n'
+            .format(
+                video_id=video_id,
+                timestamp=timestamp))
+
+    def vimeo_link(self, video_id):
+        return (
+            '<span class="video"><iframe '
+            'src="https://player.vimeo.com/video/{video_id}" '
+            'allowfullscreen></iframe></span>\n'
+            .format(video_id=video_id))
 
     def gfycat(self, video_id):
         return '<span class="video"><iframe src="https://gfycat.com/ifr/{video_id}" ' \


### PR DESCRIPTION
Changes:

* Merge all block links into one big regex.
* Create a sub parser to run the big regex on block links only instead of the whole text and every block element.

Adding a bazillion link rules/matcher should be fine now :joy_cat: 