### PR TITLE
markdown relative URL check

### DIFF
--- a/spirit/core/tests/tests_markdown.py
+++ b/spirit/core/tests/tests_markdown.py
@@ -831,7 +831,7 @@ class UtilsMarkdownTests(TestCase):
             # bypass attempt
             ('jAvAsCrIpT:alert`1`', ''),
             # javascript pseudo protocol with entities
-            ('javascript&colon;alert`1`', 'javascript&amp;colon;alert`1`'),
+            ('javascript&colon;alert`1`', ''),
             # javascript pseudo protocol with prefix (dangerous in Chrome)
             ('\x1Ajavascript:alert`1`', ''),
             # data-URI (dangerous in Firefox)
@@ -839,7 +839,7 @@ class UtilsMarkdownTests(TestCase):
             # vbscript-URI (dangerous in Internet Explorer)
             ('vbscript:msgbox', ''),
             # breaking out of the attribute
-            ('"<>', '&quot;&lt;&gt;'),
+            ('"<>', ''),
         )
 
         for vector, expected in attack_vectors:

--- a/spirit/core/utils/markdown/renderer.py
+++ b/spirit/core/utils/markdown/renderer.py
@@ -12,7 +12,9 @@ def sanitize_url(url):
     url = escape(url)  # & -> &amp; ...
     parts = url.split(':', 1)
 
-    if len(parts) == 1:  # No protocol (relative url)
+    # If there's not protocol then
+    # make sure is a relative path
+    if len(parts) == 1 and url.startswith('/'):
         return url
 
     if parts[0] in settings.ST_ALLOWED_URL_PROTOCOLS:


### PR DESCRIPTION
This was reported and debugged by @cryptogun . We should not allow relative URLs that do not start with `/`, since it creates annoyances (on images) when `SECURE_BROWSER_XSS_FILTER` is set to `True`.