### PR TITLE
send mention notifications on comment update

### DIFF
--- a/spirit/comment/utils.py
+++ b/spirit/comment/utils.py
@@ -21,8 +21,11 @@ def pre_comment_update(comment):
     CommentHistory.create_maybe(comment)
 
 
-def post_comment_update(comment):
+def post_comment_update(comment, mentions=None):
     comment.increase_modified_count()
 
     comment.comment_html = post_render_static_polls(comment)
     CommentHistory.create(comment)
+
+    TopicNotification.notify_new_mentions(
+        comment=comment, mentions=mentions)

--- a/spirit/comment/views.py
+++ b/spirit/comment/views.py
@@ -68,7 +68,7 @@ def update(request, pk):
         if form.is_valid():
             pre_comment_update(comment=Comment.objects.get(pk=comment.pk))
             comment = form.save()
-            post_comment_update(comment=comment)
+            post_comment_update(comment=comment, mentions=form.mentions)
             return redirect(request.POST.get('next', comment.get_absolute_url()))
     else:
         form = CommentForm(instance=comment)

--- a/spirit/topic/notification/models.py
+++ b/spirit/topic/notification/models.py
@@ -98,14 +98,21 @@ class TopicNotification(models.Model):
                         topic=comment.topic,
                         comment=comment,
                         action=MENTION,
-                        is_active=True
-                    )
+                        is_active=True)
             except IntegrityError:
                 pass
 
-        cls.objects\
-            .filter(user__in=mentions.values(), topic=comment.topic, is_read=True)\
-            .update(comment=comment, is_read=False, action=MENTION, date=timezone.now())
+        (cls.objects
+         .filter(
+            user__in=mentions.values(),
+            topic=comment.topic,
+            is_read=True,
+            date__lte=comment.date)
+         .update(
+            comment=comment,
+            is_read=False,
+            action=MENTION,
+            date=timezone.now()))
 
     @classmethod
     def bulk_create(cls, users, comment):


### PR DESCRIPTION
Changes:

* Create/update mention on comment update/edit if the comment's date is greater/equal than the notification's date.

The comment's date is always the same regardless of updates, so it should be ok. If the comment is older than the notification then that comment is already read, so I think there is no point in updating the notification. If the comment is way newer than the notification and there is a bunch of unread comments in the middle that should not matter. It's how mentions have always worked.