### PR TITLE
require unicode-slugify from fork

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -5,5 +5,5 @@ mistune==0.7.1
 Pillow==3.1.0
 django-infinite-scroll-pagination>=0.2.0,<0.3
 django-djconfig>=0.5.1,<0.6
-unicode-slugify==0.1.3
+http://github.com/nitely/unicode-slugify/tarball/v0.1.4#egg=unicode-slugify-0.1.4
 pytz

--- a/setup.py
+++ b/setup.py
@@ -12,13 +12,33 @@ BASE_DIR = os.path.join(os.path.dirname(__file__))
 with open(os.path.join(BASE_DIR, 'README.md')) as f:
     README = f.read()
 
-with open(os.path.join(BASE_DIR, 'requirements.txt')) as f:
-    REQUIREMENTS = f.read()
-
 VERSION = __import__('spirit').__version__
 
 # allow setup.py to be run from any path
 os.chdir(os.path.normpath(os.path.join(os.path.abspath(__file__), os.pardir)))
+
+
+with open(os.path.join(BASE_DIR, 'requirements.txt')) as f:
+    requirements = []
+    dependencies = []
+
+    for req in f.readlines():
+        req = req.strip()
+
+        if not req:
+            continue
+
+        if req.startswith(('git+', 'http://', 'https://')):
+            # Add 'git+http://...#egg=package-version'
+            # to dependencies and 'package==version'
+            # to requirements
+            _git, egg = req.split('#egg=')
+            package, version = egg.rsplit('-', 1)
+            requirements.append('%s==%s' % (package, version))
+            dependencies.append(req)
+        else:
+            requirements.append(req)
+
 
 setup(
     name='django-spirit',
@@ -32,7 +52,8 @@ setup(
     test_suite="runtests.start",
     include_package_data=True,
     zip_safe=False,
-    install_requires=REQUIREMENTS,
+    install_requires=requirements,
+    dependency_links=dependencies,
     license='MIT License',
     classifiers=[
         'Development Status :: 5 - Production/Stable',


### PR DESCRIPTION
Fixes #175 since [unicode-slugify](https://github.com/mozilla/unicode-slugify) maintainers won't fix the `setup.py` issue (see https://github.com/mozilla/unicode-slugify/pull/23 and https://github.com/mozilla/unicode-slugify/pull/22).