### PR TITLE
email timeout setting

### DIFF
--- a/example/project/settings/prod.py
+++ b/example/project/settings/prod.py
@@ -28,7 +28,7 @@ DEFAULT_FROM_EMAIL = 'webmaster@localhost'  # Django default
 SERVER_EMAIL = DEFAULT_FROM_EMAIL  # For error notifications
 
 # Email sending timeout
-EMAIL_TIMEOUT = 30  # Default is None (infinite)
+EMAIL_TIMEOUT = 20  # Default is None (infinite)
 
 # Extend the Spirit installed apps
 # Check out the .base.py file for more examples

--- a/example/project/settings/prod.py
+++ b/example/project/settings/prod.py
@@ -27,6 +27,9 @@ ALLOWED_HOSTS = ['.example.com', ]
 DEFAULT_FROM_EMAIL = 'webmaster@localhost'  # Django default
 SERVER_EMAIL = DEFAULT_FROM_EMAIL  # For error notifications
 
+# Email sending timeout
+EMAIL_TIMEOUT = 30  # Default is None (infinite)
+
 # Extend the Spirit installed apps
 # Check out the .base.py file for more examples
 INSTALLED_APPS.extend([


### PR DESCRIPTION
This just adds `EMAIL_TIMEOUT` to prod settings, otherwise if the port is blocked it will just hang[0]

[0] http://community.spirit-project.com/topic/437/email-sending-with-smtp-not-working/