### PR TITLE
Feature/make python magic optional

### DIFF
--- a/spirit/comment/tests.py
+++ b/spirit/comment/tests.py
@@ -16,10 +16,15 @@ from django.core.files.uploadedfile import SimpleUploadedFile
 from django.test.utils import override_settings
 from django.utils.six import BytesIO
 
+from . import forms as comment_forms
 from ..core.conf import settings
 from ..core.tests import utils
 from .models import Comment
-from .forms import CommentForm, CommentMoveForm, CommentImageForm
+from .forms import (
+    CommentForm,
+    CommentMoveForm,
+    CommentImageForm,
+    CommentFileForm)
 from .tags import render_comments_form
 from ..core.utils import markdown
 from .views import delete as comment_delete
@@ -793,6 +798,25 @@ class CommentFormTest(TestCase):
         files = {'image': SimpleUploadedFile('image.gif', img.read(), content_type='image/gif'), }
         form = CommentImageForm(data={}, files=files)
         self.assertFalse(form.is_valid())
+
+    def test_comment_file_upload_no_libmagic(self):
+        """
+        Magic lib should be optional
+        """
+        utils.login(self)
+        file = BytesIO(
+            b'%PDF-1.0\n1 0 obj<</Type/Catalog/Pages 2 0 R>>endobj 2 0 obj<</Type/Pages/Kids[3 0 R]/Count 1'
+            b'>>endobj 3 0 obj<</Type/Page/MediaBox[0 0 3 3]>>endobj\nxref\n0 4\n0000000000 65535 f\n000000'
+            b'0010 00000 n\n0000000053 00000 n\n0000000102 00000 n\ntrailer<</Size 4/Root 1 0 R>>\nstartxre'
+            b'f\n149\n%EOF\n')
+        files = {'file': SimpleUploadedFile('file.pdf', file.read(), content_type='application/pdf'),}
+        form = CommentFileForm(data={}, files=files)
+
+        comment_forms_magic_orig, comment_forms.magic = comment_forms.magic, None
+        try:
+            self.assertFalse(form.is_valid())
+        finally:
+            comment_forms.magic = comment_forms_magic_orig
 
     def test_comment_max_len(self):
         """


### PR DESCRIPTION
Makes python-magic optional. This is mostly for Windows users who don't need file upload and won't install cygwin libmagic.