### PR TITLE
Option to forbid viewing other's modification history.

### DIFF
--- a/spirit/comment/history/views.py
+++ b/spirit/comment/history/views.py
@@ -3,7 +3,9 @@
 from __future__ import unicode_literals
 
 from django.contrib.auth.decorators import login_required
+from django.http import Http404
 from django.shortcuts import render, get_object_or_404
+from django.utils.translation import ugettext as _
 
 from djconfig import config
 
@@ -16,6 +18,12 @@ from ..models import Comment
 def detail(request, comment_id):
     comment = get_object_or_404(Comment.objects.for_access(request.user),
                                 pk=comment_id)
+
+    # not comment author and not moderator:
+    if request.user != comment.user and not request.user.st.is_moderator:
+        raise Http404(
+            _("You have no right to view other's modification history.")
+        )
 
     comments = CommentHistory.objects\
         .filter(comment_fk=comment)\

--- a/spirit/comment/templates/spirit/comment/_render_list.html
+++ b/spirit/comment/templates/spirit/comment/_render_list.html
@@ -1,7 +1,7 @@
 {% load spirit_tags i18n %}
 
 <div class="comments">
-
+    {% load_settings "ST_CUSTOMIZE_ALLOW_OTHERS_VIEWING_MODIFICATION_HISTORY" %}
     {% for c in comments %}
 
 		<div class="comment{% if c.action %} is-highlighted{% endif %}" id="c{{forloop.counter0|add:comments.start_index }}" data-number="{{ forloop.counter0|add:comments.start_index }}" data-pk="{{ c.pk }}">
@@ -22,7 +22,9 @@
 
                             <ul class="comment-date">
                                 {% if c.modified_count > 0 %}
+                                    {% if user.st.is_moderator or st_settings.ST_CUSTOMIZE_ALLOW_OTHERS_VIEWING_MODIFICATION_HISTORY or c.user == user %}
                                     <li><a href="{% url "spirit:comment:history:detail" comment_id=c.pk %}"><i class="fa fa-pencil"></i> {{ c.modified_count }}</a></li>
+                                    {% endif %}
                                 {% endif %}
 
                                 <li title="{{ c.date }}">{{ c.date|shortnaturaltime }}</li>

--- a/spirit/core/conf/defaults.py
+++ b/spirit/core/conf/defaults.py
@@ -100,3 +100,5 @@ ST_BASE_DIR = (
     os.path.dirname(
         os.path.dirname(
             os.path.dirname(__file__))))
+
+ST_CUSTOMIZE_ALLOW_OTHERS_VIEWING_MODIFICATION_HISTORY = False


### PR DESCRIPTION
For privacy concern.
Comment author can view their own comment modification history, but not other user's.
Moderators can view anyone's history.
Switch: `ST_CUSTOMIZE_ALLOW_OTHERS_VIEWING_MODIFICATION_HISTORY`