### PR TITLE
Order topic notification based on unread, date and pk.

### DIFF
--- a/spirit/topic/notification/models.py
+++ b/spirit/topic/notification/models.py
@@ -35,7 +35,7 @@ class TopicNotification(models.Model):
 
     class Meta:
         unique_together = ('user', 'topic')
-        ordering = ['-date', '-pk']
+        ordering = ['is_read', '-date', '-pk']
         verbose_name = _("topic notification")
         verbose_name_plural = _("topics notification")
 


### PR DESCRIPTION
As the title. If we replied too many topics, It become harder and harder to find un-read topics.
Once viewed, that topic is back to [date, pk] order.