### PR TITLE
Fix #163. Always increase bookmarks.

### DIFF
--- a/spirit/comment/bookmark/forms.py
+++ b/spirit/comment/bookmark/forms.py
@@ -23,5 +23,7 @@ class BookmarkForm(forms.ModelForm):
 
         # Bookmark is created/updated on topic view.
         CommentBookmark.objects\
-            .filter(user=self.user, topic=self.topic)\
+            .filter(user=self.user,
+                    topic=self.topic,
+                    comment_number__lt=comment_number)\
             .update(comment_number=comment_number)

--- a/spirit/comment/bookmark/models.py
+++ b/spirit/comment/bookmark/models.py
@@ -56,10 +56,20 @@ class CommentBookmark(models.Model):
         if comment_number is None:
             return
 
-        bookmark, created = cls.objects.update_or_create(
-            user=user,
-            topic=topic,
-            defaults={'comment_number': comment_number, }
-        )
+        changed = False
+        try:
+            bookmark = cls.objects.get(user=user, topic=topic)
+        except cls.DoesNotExist:
+            changed = True
+            bookmark = cls.objects.create(user=user,
+                                          topic=topic,
+                                          comment_number=0)
+
+        if comment_number > bookmark.comment_number:
+            changed = True
+            bookmark.comment_number = comment_number
+
+        if changed:
+            bookmark.save()
 
         return bookmark


### PR DESCRIPTION
1. Browse previous pages won't decrease bookmark any more.
2. And won't get a red notice if you browse back. You won't be curious clicking the *fake* notification any more.
3. Hence reduce database modification.