### PR TITLE
Fix 156.2. Focus back to input field.

### DIFF
--- a/spirit/core/static/spirit/scripts/src/editor.coffee
+++ b/spirit/core/static/spirit/scripts/src/editor.coffee
@@ -54,38 +54,32 @@ class Editor
 
         @el.val(preSelection + preTxt + selection + postTxt + postSelection)
 
-    addBold: (e) =>
-        e.preventDefault()
+    addBold: =>
         @wrapSelection("**", "**", @options.boldedText)
         $('#id_comment').focus()
         return false
 
-    addItalic: (e) =>
-        e.preventDefault()
+    addItalic: =>
         @wrapSelection("*", "*", @options.italicisedText)
         $('#id_comment').focus()
         return false
 
-    addList: (e) =>
-        e.preventDefault()
+    addList: =>
         @wrapSelection("\n* ", "", @options.listItemText)
         $('#id_comment').focus()
         return false
 
-    addUrl: (e) =>
-        e.preventDefault()
+    addUrl: =>
         @wrapSelection("[", "](#{ @options.linkUrlText })", @options.linkText)
         $('#id_comment').focus()
         return false
 
-    addImage: (e) =>
-        e.preventDefault()
+    addImage: =>
         @wrapSelection("![", "](#{ @options.imageUrlText })", @options.imageText)
         $('#id_comment').focus()
         return false
 
-    addPoll: (e) =>
-        e.preventDefault()
+    addPoll: =>
         poll = "\n\n[poll name=#{@pollCounter}]\n" +
             "# #{@options.pollTitleText}\n" +
             "1. #{@options.pollChoiceText}\n" +

--- a/spirit/core/static/spirit/scripts/src/editor.coffee
+++ b/spirit/core/static/spirit/scripts/src/editor.coffee
@@ -54,27 +54,38 @@ class Editor
 
         @el.val(preSelection + preTxt + selection + postTxt + postSelection)
 
-    addBold: =>
+    addBold: (e) =>
+        e.preventDefault()
         @wrapSelection("**", "**", @options.boldedText)
+        $('#id_comment').focus()
         return false
 
-    addItalic: =>
+    addItalic: (e) =>
+        e.preventDefault()
         @wrapSelection("*", "*", @options.italicisedText)
+        $('#id_comment').focus()
         return false
 
-    addList: =>
+    addList: (e) =>
+        e.preventDefault()
         @wrapSelection("\n* ", "", @options.listItemText)
+        $('#id_comment').focus()
         return false
 
-    addUrl: =>
+    addUrl: (e) =>
+        e.preventDefault()
         @wrapSelection("[", "](#{ @options.linkUrlText })", @options.linkText)
+        $('#id_comment').focus()
         return false
 
-    addImage: =>
+    addImage: (e) =>
+        e.preventDefault()
         @wrapSelection("![", "](#{ @options.imageUrlText })", @options.imageText)
+        $('#id_comment').focus()
         return false
 
-    addPoll: =>
+    addPoll: (e) =>
+        e.preventDefault()
         poll = "\n\n[poll name=#{@pollCounter}]\n" +
             "# #{@options.pollTitleText}\n" +
             "1. #{@options.pollChoiceText}\n" +
@@ -82,6 +93,7 @@ class Editor
             "[/poll]\n"
         @wrapSelection("", poll, "")  # todo: append to current pointer position
         @pollCounter++
+        $('#id_comment').focus()
         return false
 
     togglePreview: =>


### PR DESCRIPTION
After clicked format buttons (below the input text field), we should focus cusor back to the input field.
Also prevent jump to top (#foobar html id).