### PR TITLE
Add LGTM code quality badges

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,8 @@
 [![Coverage Status](https://img.shields.io/coveralls/nitely/Spirit.svg?style=flat-square)](https://coveralls.io/r/nitely/Spirit)
 [![pypi](https://img.shields.io/pypi/v/django-spirit.svg?style=flat-square)](https://pypi.python.org/pypi/django-spirit)
 [![licence](https://img.shields.io/pypi/l/django-spirit.svg?style=flat-square)](https://raw.githubusercontent.com/nitely/Spirit/master/LICENSE)
+[![Code Quality: Python](https://img.shields.io/lgtm/grade/python/g/nitely/Spirit.svg?logo=lgtm&logoWidth=18)](https://lgtm.com/projects/g/nitely/Spirit/context:python)
+[![Total Alerts](https://img.shields.io/lgtm/alerts/g/nitely/Spirit.svg?logo=lgtm&logoWidth=18)](https://lgtm.com/projects/g/nitely/Spirit/alerts)
 
 Spirit is a Python based forum built using the Django framework.
 


### PR DESCRIPTION
Hi there!

I thought you might be interested in adding these LGTM [code quality badges](https://lgtm.com/projects/g/nitely/Spirit/ci/#badges) to your project. They indicate how you care about code quality and encourage your future contributors to do the same.
To get an idea of the analyses reflected by these grades, check the [alerts discovered by LGTM](https://lgtm.com/projects/g/nitely/Spirit).

N.B.: I am on the team behind LGTM.com, I'd appreciate your feedback on this initiative, whether you're interested or not, if you find time to drop me a line. Thanks.
