### PR TITLE
Markdown math support

### DIFF
--- a/spirit/core/conf/defaults.py
+++ b/spirit/core/conf/defaults.py
@@ -38,6 +38,11 @@ ST_MENTIONS_PER_COMMENT = 30
 #: Minutes to wait before a given user
 #: will be able to post a duplicated comment/topic
 ST_DOUBLE_POST_THRESHOLD_MINUTES = 30
+#: Enable MathJax. Spirit's markdown supports
+#: math notation with ``$$...$$``, ``\(...\)``, ``\[...\]``
+#: and ``\begin{abc}...\end{abc}``, this merely insert the
+#: MathJax script into the HTML.
+ST_MATH_JAX = False
 
 #: Number of next/previous pages the paginator will show
 ST_YT_PAGINATOR_PAGE_RANGE = 3

--- a/spirit/core/templates/spirit/_footer.html
+++ b/spirit/core/templates/spirit/_footer.html
@@ -1,3 +1,6 @@
+{% load spirit_tags %}
+{% load_settings 'ST_MATH_JAX' %}
+
 {{ config.template_footer|safe }}
 
 {% spaceless %}
@@ -7,3 +10,18 @@
     </div>
   </footer>
 {% endspaceless %}
+
+{% if st_settings.ST_MATH_JAX %}
+  <script type="text/x-mathjax-config">
+    (function () {
+      var elms = document.querySelectorAll(".math");
+      MathJax.Hub.Config({
+        elements: elms,
+        skipStartupTypeset: elms.length === 0
+      });
+    })();
+  </script>
+  <script type="text/javascript" async
+    src="https://cdnjs.cloudflare.com/ajax/libs/mathjax/2.7.5/MathJax.js?config=TeX-MML-AM_CHTML">
+  </script>
+{% endif %}

--- a/spirit/core/tests/tests_markdown.py
+++ b/spirit/core/tests/tests_markdown.py
@@ -898,7 +898,17 @@ class UtilsMarkdownTests(TestCase):
             "4 * 4\n"
             "$$\n")
         comment_md = Markdown().render(comment)
-        self.assertEqual(comment_md, '<p>hey <em>foo</em></p>\n$$\n2 * 2\n4 * 4\n$$')
+        self.assertEqual(comment_md, '<p>hey <em>foo</em></p>\n<p>$$\n2 * 2\n4 * 4\n$$</p>')
+
+    def test_markdown_math_multi_line_latex(self):
+        comment = (
+            "$$\\begin{...}\n"
+            "2 * 2\n"
+            "4 * 4\n"
+            "\\end{...}$$\n")
+        comment_md = Markdown().render(comment)
+        self.assertEqual(
+            comment_md, '<p>$$\\begin{...}\n2 * 2\n4 * 4\n\\end{...}$$</p>')
 
     def test_markdown_mathjax(self):
         comment = (
@@ -921,6 +931,6 @@ class UtilsMarkdownTests(TestCase):
         self.assertEqual(
             comment_md,
             '<p>$$ x &lt; y $$</p>\n'
-            '$$\n x &lt; y\n $$\n'
+            '<p>$$\n x &lt; y\n $$</p>\n'
             '<p>\\( x &lt; y \\)</p>\n'
             '<p>\\[ x &lt; y \\]</p>')

--- a/spirit/core/tests/tests_markdown.py
+++ b/spirit/core/tests/tests_markdown.py
@@ -879,3 +879,48 @@ class UtilsMarkdownTests(TestCase):
             self.assertEqual(
                 Markdown().render('[atk](%s)' % vector),
                 '<p><a rel="nofollow" href="%s">atk</a></p>' % expected)
+
+    def test_markdown_math(self):
+        comment = "hey *foo* $$2 * 2$$ *bar* bye"
+        comment_md = Markdown().render(comment)
+        self.assertEqual(comment_md, '<p>hey <em>foo</em> $$2 * 2$$ <em>bar</em> bye</p>')
+
+    def test_markdown_math_parens(self):
+        comment = r"hey *foo* \(2 * 2\) *bar* bye"
+        comment_md = Markdown().render(comment)
+        self.assertEqual(comment_md, r'<p>hey <em>foo</em> \(2 * 2\) <em>bar</em> bye</p>')
+
+    def test_markdown_math_multi_line(self):
+        comment = (
+            "hey *foo*\n\n"
+            "$$\n"
+            "2 * 2\n"
+            "4 * 4\n"
+            "$$\n")
+        comment_md = Markdown().render(comment)
+        self.assertEqual(comment_md, '<p>hey <em>foo</em></p>\n$$\n2 * 2\n4 * 4\n$$')
+
+    def test_markdown_mathjax(self):
+        comment = (
+            r"When \(a \ne 0\), there are two solutions to \(ax^2 + bx + c = 0\) and they are\n"
+            r"$$x = {-b \pm \sqrt{b^2-4ac} \over 2a}.$$")
+        comment_md = Markdown().render(comment)
+        self.assertEqual(
+            comment_md,
+            r'<p>When \(a \ne 0\), there are two solutions to \(ax^2 + bx + c = 0\) and they are\n'
+            r'$$x = {-b \pm \sqrt{b^2-4ac} \over 2a}.$$</p>')
+
+    def test_markdown_math_xss(self):
+        comment = (
+            "$$ x < y $$\n\n"
+            "$$\n x < y\n $$\n\n"
+            "\\( x < y \\)\n\n"
+            "\\[ x < y \\]\n\n")
+        comment_md = Markdown().render(comment)
+        self.maxDiff = None
+        self.assertEqual(
+            comment_md,
+            '<p>$$ x &lt; y $$</p>\n'
+            '$$\n x &lt; y\n $$\n'
+            '<p>\\( x &lt; y \\)</p>\n'
+            '<p>\\[ x &lt; y \\]</p>')

--- a/spirit/core/tests/tests_markdown.py
+++ b/spirit/core/tests/tests_markdown.py
@@ -958,3 +958,8 @@ class UtilsMarkdownTests(TestCase):
             comment_md,
             '<p><a rel="nofollow" href="http://example.com" '
             'title="this is a title \\(2 * 2\\) ">this is a link [2 * 2]</a></p>')
+
+    def test_markdown_math_not_a_link(self):
+        comment = "\\[this is not]\\(a link)"
+        comment_md = Markdown().render(comment)
+        self.assertEqual(comment_md, '<p>[this is not](a link)</p>')

--- a/spirit/core/tests/tests_markdown.py
+++ b/spirit/core/tests/tests_markdown.py
@@ -948,3 +948,13 @@ class UtilsMarkdownTests(TestCase):
             '<p class="math">$$\n x &lt; y\n $$</p>\n'
             '<p><span class="math">\\( x &lt; y \\)</span></p>\n'
             '<p class="math">\\[ x &lt; y \\]</p>')
+
+    def test_markdown_math_not_within_link(self):
+        comment = (
+            "[this is a link \\[2 * 2\\]]"
+            "(http://example.com \"this is a title \\(2 * 2\\) \")")
+        comment_md = Markdown().render(comment)
+        self.assertEqual(
+            comment_md,
+            '<p><a rel="nofollow" href="http://example.com" '
+            'title="this is a title \\(2 * 2\\) ">this is a link [2 * 2]</a></p>')

--- a/spirit/core/tests/tests_markdown.py
+++ b/spirit/core/tests/tests_markdown.py
@@ -880,15 +880,14 @@ class UtilsMarkdownTests(TestCase):
                 Markdown().render('[atk](%s)' % vector),
                 '<p><a rel="nofollow" href="%s">atk</a></p>' % expected)
 
-    def test_markdown_math(self):
-        comment = "hey *foo* $$2 * 2$$ *bar* bye"
+    def test_markdown_math_inline(self):
+        comment = "hey *foo* \\(2 * 2\\) *bar* bye"
         comment_md = Markdown().render(comment)
-        self.assertEqual(comment_md, '<p>hey <em>foo</em> $$2 * 2$$ <em>bar</em> bye</p>')
-
-    def test_markdown_math_parens(self):
-        comment = r"hey *foo* \(2 * 2\) *bar* bye"
-        comment_md = Markdown().render(comment)
-        self.assertEqual(comment_md, r'<p>hey <em>foo</em> \(2 * 2\) <em>bar</em> bye</p>')
+        self.assertEqual(
+            comment_md,
+            '<p>hey <em>foo</em> '
+            '<span class="math">\\(2 * 2\\)</span> '
+            '<em>bar</em> bye</p>')
 
     def test_markdown_math_multi_line(self):
         comment = (
@@ -898,27 +897,42 @@ class UtilsMarkdownTests(TestCase):
             "4 * 4\n"
             "$$\n")
         comment_md = Markdown().render(comment)
-        self.assertEqual(comment_md, '<p>hey <em>foo</em></p>\n<p>$$\n2 * 2\n4 * 4\n$$</p>')
+        self.assertEqual(
+            comment_md,
+            '<p>hey <em>foo</em></p>\n'
+            '<p class="math">$$\n'
+            '2 * 2\n'
+            '4 * 4\n'
+            '$$</p>')
 
-    def test_markdown_math_multi_line_latex(self):
+    def test_markdown_math_latex(self):
         comment = (
-            "$$\\begin{...}\n"
+            "\\begin{...}\n"
             "2 * 2\n"
             "4 * 4\n"
-            "\\end{...}$$\n")
-        comment_md = Markdown().render(comment)
-        self.assertEqual(
-            comment_md, '<p>$$\\begin{...}\n2 * 2\n4 * 4\n\\end{...}$$</p>')
-
-    def test_markdown_mathjax(self):
-        comment = (
-            r"When \(a \ne 0\), there are two solutions to \(ax^2 + bx + c = 0\) and they are\n"
-            r"$$x = {-b \pm \sqrt{b^2-4ac} \over 2a}.$$")
+            "\\end{...}\n")
         comment_md = Markdown().render(comment)
         self.assertEqual(
             comment_md,
-            r'<p>When \(a \ne 0\), there are two solutions to \(ax^2 + bx + c = 0\) and they are\n'
-            r'$$x = {-b \pm \sqrt{b^2-4ac} \over 2a}.$$</p>')
+            '<p class="math">\\begin{...}\n'
+            '2 * 2\n'
+            '4 * 4\n'
+            '\\end{...}</p>')
+
+    def test_markdown_mathjax(self):
+        comment = (
+            "When \\(a \\ne 0\\), there are two solutions to "
+            "\\(ax^2 + bx + c = 0\\) and they are\n\n"
+            "$$x = {-b \\pm \\sqrt{b^2-4ac} \\over 2a}.$$")
+        comment_md = Markdown().render(comment)
+        self.assertEqual(
+            comment_md,
+            '<p>When '
+            '<span class="math">\\(a \\ne 0\\)</span>'
+            ', there are two solutions to '
+            '<span class="math">\\(ax^2 + bx + c = 0\\)</span>'
+            ' and they are</p>\n'
+            '<p class="math">$$x = {-b \\pm \\sqrt{b^2-4ac} \\over 2a}.$$</p>')
 
     def test_markdown_math_xss(self):
         comment = (
@@ -930,7 +944,7 @@ class UtilsMarkdownTests(TestCase):
         self.maxDiff = None
         self.assertEqual(
             comment_md,
-            '<p>$$ x &lt; y $$</p>\n'
-            '<p>$$\n x &lt; y\n $$</p>\n'
-            '<p>\\( x &lt; y \\)</p>\n'
-            '<p>\\[ x &lt; y \\]</p>')
+            '<p class="math">$$ x &lt; y $$</p>\n'
+            '<p class="math">$$\n x &lt; y\n $$</p>\n'
+            '<p><span class="math">\\( x &lt; y \\)</span></p>\n'
+            '<p class="math">\\[ x &lt; y \\]</p>')

--- a/spirit/core/tests/tests_templates.py
+++ b/spirit/core/tests/tests_templates.py
@@ -1,0 +1,25 @@
+# -*- coding: utf-8 -*-
+
+from __future__ import unicode_literals
+
+from django.test import TestCase, override_settings
+from django.template.loader import render_to_string
+
+from . import utils
+
+
+class TemplatesTests(TestCase):
+    def setUp(self):
+        self.user = utils.create_user()
+
+    @override_settings(ST_MATH_JAX=True)
+    def test_math_jax(self):
+        tpl = render_to_string('spirit/_footer.html')
+        self.assertTrue('MathJax.js' in tpl)
+        self.assertTrue('x-mathjax-config' in tpl)
+
+    @override_settings(ST_MATH_JAX=False)
+    def test_math_jax_disabled(self):
+        tpl = render_to_string('spirit/_footer.html')
+        self.assertFalse('MathJax.js' in tpl)
+        self.assertFalse('x-mathjax-config' in tpl)

--- a/spirit/core/utils/markdown/block.py
+++ b/spirit/core/utils/markdown/block.py
@@ -12,9 +12,16 @@ from .parsers.poll import PollParser
 
 class BlockGrammar(mistune.BlockGrammar):
     block_math = re.compile(
-        r'^ *\$\$'
-        r'( *(?:\S+)? *\n[\s\S]+?\s*)'  # $$\begin{...}\n...$$
-        r'\$\$ *(?:\n+|$)'
+        r'^ *\$\$([\s\S]+?)\$\$ *(?:\n+|$)'
+    )
+
+    block_math_brackets = re.compile(
+        r'^ *\\\[([\s\S]+?)\\\] *(?:\n+|$)'
+    )
+
+    block_latex = re.compile(
+        r'^\\begin\{([^\}\*]*\*?)\}([\s\S]+?)\\end\{\1\}'
+        r'(?:\n+|$)'
     )
 
     block_link = re.compile(
@@ -127,6 +134,8 @@ class BlockLexer(mistune.BlockLexer):
 
     default_rules = copy.copy(mistune.BlockLexer.default_rules)
     default_rules.insert(0, 'block_math')
+    default_rules.insert(0, 'block_math_brackets')
+    default_rules.insert(0, 'block_latex')
     default_rules.insert(0, 'block_link')
     default_rules.insert(0, 'poll')
 
@@ -154,6 +163,19 @@ class BlockLexer(mistune.BlockLexer):
         self.tokens.append({
             'type': 'block_math',
             'text': m.group(1)
+        })
+
+    def parse_block_math_brackets(self, m):
+        self.tokens.append({
+            'type': 'block_math_brackets',
+            'text': m.group(1)
+        })
+
+    def parse_block_latex(self, m):
+        self.tokens.append({
+            'type': 'block_latex',
+            'name': m.group(1),
+            'text': m.group(2)
         })
 
     def parse_block_link(self, m):

--- a/spirit/core/utils/markdown/block.py
+++ b/spirit/core/utils/markdown/block.py
@@ -11,6 +11,11 @@ from .parsers.poll import PollParser
 
 
 class BlockGrammar(mistune.BlockGrammar):
+    block_math = re.compile(
+        r'^ *\$\$'
+        r'( *(?:\S+)? *\n[\s\S]+?\s*)'  # $$\begin{...}\n...$$
+        r'\$\$ *(?:\n+|$)'
+    )
 
     block_link = re.compile(
         r'^https?://[^\s]+'
@@ -121,6 +126,7 @@ class BlockGrammar(mistune.BlockGrammar):
 class BlockLexer(mistune.BlockLexer):
 
     default_rules = copy.copy(mistune.BlockLexer.default_rules)
+    default_rules.insert(0, 'block_math')
     default_rules.insert(0, 'block_link')
     default_rules.insert(0, 'poll')
 
@@ -143,6 +149,12 @@ class BlockLexer(mistune.BlockLexer):
             'polls': [],
             'choices': []
         }
+
+    def parse_block_math(self, m):
+        self.tokens.append({
+            'type': 'block_math',
+            'text': m.group(1)
+        })
 
     def parse_block_link(self, m):
         link = m.group(0).strip()

--- a/spirit/core/utils/markdown/inline.py
+++ b/spirit/core/utils/markdown/inline.py
@@ -14,11 +14,16 @@ from .utils.emoji import emojis
 User = get_user_model()
 _linebreak = re.compile(r'^ *\n(?!\s*$)')
 _text = re.compile(
-    r'^[\s\S]+?(?=[\\<!\[_*`:@~]|https?://| *\n|$)'
+    r'^[\s\S]+?(?=[\\<!\[_*`:@~\$]|https?://| *\n|$)'
 )
 
 
 class InlineGrammar(mistune.InlineGrammar):
+
+    math = re.compile(
+        r'^\$\$(.+?)\$\$')
+    math_escaped = re.compile(
+        r'^(\\\(.+?\\\)|\\\[.+?\\\])')
 
     # todo: match unicode emojis
     emoji = re.compile(
@@ -40,6 +45,8 @@ class InlineGrammar(mistune.InlineGrammar):
 class InlineLexer(mistune.InlineLexer):
 
     default_rules = copy.copy(mistune.InlineLexer.default_rules)
+    default_rules.insert(2, 'math')
+    default_rules.insert(0, 'math_escaped')
     default_rules.insert(2, 'emoji')
     default_rules.insert(2, 'mention')
 
@@ -51,6 +58,12 @@ class InlineLexer(mistune.InlineLexer):
 
         self.mentions = {}
         self._mention_count = 0
+
+    def output_math(self, m):
+        return self.renderer.math(m.group(1))
+
+    def output_math_escaped(self, m):
+        return self.renderer.math_escaped(m.group(1))
 
     def output_emoji(self, m):
         emoji = m.group('emoji')

--- a/spirit/core/utils/markdown/inline.py
+++ b/spirit/core/utils/markdown/inline.py
@@ -14,16 +14,14 @@ from .utils.emoji import emojis
 User = get_user_model()
 _linebreak = re.compile(r'^ *\n(?!\s*$)')
 _text = re.compile(
-    r'^[\s\S]+?(?=[\\<!\[_*`:@~\$]|https?://| *\n|$)'
+    r'^[\s\S]+?(?=[\\<!\[_*`:@~]|https?://| *\n|$)'
 )
 
 
 class InlineGrammar(mistune.InlineGrammar):
 
     math = re.compile(
-        r'^\$\$(.+?)\$\$')
-    math_escaped = re.compile(
-        r'^(\\\(.+?\\\)|\\\[.+?\\\])')
+        r'^\\\((.+?)\\\)')
 
     # todo: match unicode emojis
     emoji = re.compile(
@@ -45,8 +43,7 @@ class InlineGrammar(mistune.InlineGrammar):
 class InlineLexer(mistune.InlineLexer):
 
     default_rules = copy.copy(mistune.InlineLexer.default_rules)
-    default_rules.insert(2, 'math')
-    default_rules.insert(0, 'math_escaped')
+    default_rules.insert(0, 'math')
     default_rules.insert(2, 'emoji')
     default_rules.insert(2, 'mention')
 
@@ -61,9 +58,6 @@ class InlineLexer(mistune.InlineLexer):
 
     def output_math(self, m):
         return self.renderer.math(m.group(1))
-
-    def output_math_escaped(self, m):
-        return self.renderer.math_escaped(m.group(1))
 
     def output_emoji(self, m):
         emoji = m.group('emoji')

--- a/spirit/core/utils/markdown/markdown.py
+++ b/spirit/core/utils/markdown/markdown.py
@@ -38,6 +38,10 @@ class Markdown(mistune.Markdown):
     def get_polls(self):
         return self.block.polls
 
+    def output_block_math(self):
+        return self.renderer.block_math(
+            text=self.token['text'])
+
     def output_block_link(self):
         return self.renderer.block_link(
             link=self.token['link'])

--- a/spirit/core/utils/markdown/markdown.py
+++ b/spirit/core/utils/markdown/markdown.py
@@ -42,6 +42,15 @@ class Markdown(mistune.Markdown):
         return self.renderer.block_math(
             text=self.token['text'])
 
+    def output_block_math_brackets(self):
+        return self.renderer.block_math_brackets(
+            text=self.token['text'])
+
+    def output_block_latex(self):
+        return self.renderer.block_latex(
+            text=self.token['text'],
+            name=self.token['name'])
+
     def output_block_link(self):
         return self.renderer.block_link(
             link=self.token['link'])

--- a/spirit/core/utils/markdown/renderer.py
+++ b/spirit/core/utils/markdown/renderer.py
@@ -27,7 +27,7 @@ def sanitize_url(url):
 class Renderer(mistune.Renderer):
 
     def block_math(self, text):
-        return '$$%s$$\n' % escape(text)
+        return '<p>$$%s$$</p>\n' % escape(text)
 
     def math(self, text):
         return '$$%s$$' % escape(text)

--- a/spirit/core/utils/markdown/renderer.py
+++ b/spirit/core/utils/markdown/renderer.py
@@ -26,6 +26,15 @@ def sanitize_url(url):
 
 class Renderer(mistune.Renderer):
 
+    def block_math(self, text):
+        return '$$%s$$\n' % escape(text)
+
+    def math(self, text):
+        return '$$%s$$' % escape(text)
+
+    def math_escaped(self, text):
+        return escape(text)
+
     # Override
     def autolink(self, link, is_email=False):
         link = sanitize_url(link)

--- a/spirit/core/utils/markdown/renderer.py
+++ b/spirit/core/utils/markdown/renderer.py
@@ -27,13 +27,18 @@ def sanitize_url(url):
 class Renderer(mistune.Renderer):
 
     def block_math(self, text):
-        return '<p>$$%s$$</p>\n' % escape(text)
+        return '<p class="math">$$%s$$</p>\n' % escape(text)
+
+    def block_math_brackets(self, text):
+        return '<p class="math">\\[%s\\]</p>\n' % escape(text)
+
+    def block_latex(self, text, name):
+        name = escape(name)
+        text = escape(text)
+        return '<p class="math">\\begin{%s}%s\\end{%s}</p>\n' % (name, text, name)
 
     def math(self, text):
-        return '$$%s$$' % escape(text)
-
-    def math_escaped(self, text):
-        return escape(text)
+        return '<span class="math">\\(%s\\)</span>' % escape(text)
 
     # Override
     def autolink(self, link, is_email=False):


### PR DESCRIPTION
fixes #261

- Implements mathJax: `$$...$$` (block), `\(...\)` (inline), `\[...\]` (block) and `\begin{...}...\end{...}` (block). 

The following markdown will get rendered as it should, except for `$...$` which is not supported because that's too likely to be used in non math text, use `\(...\)` instead.

```markdown
#### TeX Samples

The following equations are represented in the HTML source code as LaTeX expressions.

**The Lorenz Equations**

\begin{aligned}
\dot{x} & = \sigma(y-x) \\
\dot{y} & = \rho x - y - xz \\
\dot{z} & = -\beta z + xy
\end{aligned}

**The Cauchy-Schwarz Inequality**

\[
\left( \sum_{k=1}^n a_k b_k \right)^2 \leq \left( \sum_{k=1}^n a_k^2 \right) \left( \sum_{k=1}^n b_k^2 \right)
\]

**A Cross Product Formula**

\[ \mathbf{V}_1 \times \mathbf{V}_2 =  \begin{vmatrix}
\mathbf{i} & \mathbf{j} & \mathbf{k} \\
\frac{\partial X}{\partial u} &  \frac{\partial Y}{\partial u} & 0 \\
\frac{\partial X}{\partial v} &  \frac{\partial Y}{\partial v} & 0
\end{vmatrix} \]

**The probability of getting $k$ heads when flipping $n$ coins is**

$$P(E)   = {n \choose k} p^k (1-p)^{ n-k}$$

**A Rogers-Ramanujan Identity**

\[1 +  \frac{q^2}{(1-q)}+\frac{q^6}{(1-q)(1-q^2)}+\cdots =
\prod_{j=0}^{\infty}\frac{1}{(1-q^{5j+2})(1-q^{5j+3})},
\quad\quad \text{for $|q|<1$}.\]

**Maxwell’s Equations**

\begin{aligned}
\nabla \times \vec{\mathbf{B}} -\, \frac1c\, \frac{\partial\vec{\mathbf{E}}}{\partial t} & = \frac{4\pi}{c}\vec{\mathbf{j}} \\   \nabla \cdot \vec{\mathbf{E}} & = 4 \pi \rho \\
\nabla \times \vec{\mathbf{E}}\, +\, \frac1c\, \frac{\partial\vec{\mathbf{B}}}{\partial t} & = \vec{\mathbf{0}} \\
\nabla \cdot \vec{\mathbf{B}} & = 0 \end{aligned}

Finally, while display equations look good for a page of samples, the ability to mix math and text in a paragraph is also important. This expression $\sqrt{3×-1}+(1+x)^2$ is an example of an inline equation. As you see, MathJax equations can be used this way as well, without unduly disturbing the spacing between lines. 
```

The template requires to config mathjax to just process `math` elements, otherwise it may process more than it should:

```html
<script type="text/x-mathjax-config">
    // We need a dummy element because empty means process every node
    var elms = document.querySelectorAll(".math");
    MathJax.Hub.Config(
        {
           elements: elms.length > 0 ? elms : [document.createElement('div')]
        }
    );
</script>
<script type="text/javascript" async
  src="https://cdnjs.cloudflare.com/ajax/libs/mathjax/2.7.5/MathJax.js?config=TeX-MML-AM_CHTML">
</script>
```