### PR TITLE
Revert #292

### DIFF
--- a/spirit/core/templates/spirit/_base.html
+++ b/spirit/core/templates/spirit/_base.html
@@ -25,7 +25,7 @@
       {% if user.is_authenticated %}
         stModules.notification(document.querySelectorAll('.js-tab-notification'), {
           notificationUrl: "{% url "spirit:topic:notification:index-ajax" %}",
-          notificationListUrl: "{% url "spirit:topic:notification:index" %}",
+          notificationListUrl: "{% url "spirit:topic:notification:index-unread" %}",
           mentionTxt: "{% trans "{user} has mention you on {topic}" %}",
           commentTxt: "{% trans "{user} has commented on {topic}" %}",
           showAll: "{% trans "Show all" %}",

--- a/spirit/topic/notification/templates/spirit/topic/notification/_top_bar.html
+++ b/spirit/topic/notification/templates/spirit/topic/notification/_top_bar.html
@@ -1,9 +1,35 @@
 {% load i18n %}
 
 <div class="layout__menu">
-  <div class="menu__dropdown">
+  <div class="menu__dropdown js-tabs-container">
     <div class="menu__dropdown_button">
-      <span class="dropdown_button">{% trans "Notifications" %}</span>
+      {% if active == "notifications" %}
+        <a
+          class="dropdown_button js-tab"
+          href="#"
+          data-related=".js-categories-content"
+        >{% trans "Notifications" %} <i class="fa fa-chevron-down"></i></a>
+        {% else %}
+        <a
+          class="dropdown_button js-tab"
+          href="#"
+          data-related=".js-categories-content"
+        >{% trans "Unread notifications" %} <i class="fa fa-chevron-down"></i></a>
+      {% endif %}
+    </div>
+    <div class="menu_list_wrapper js-tab-content js-categories-content" style="display: none;">
+      {% spaceless %}
+        <ul class="menu_list">
+          <li><a
+            class="menu_list__link"
+            href="{% url "spirit:topic:notification:index" %}"
+            >{% trans "Notifications" %}</a></li>
+          <li><a
+            class="menu_list__link"
+            href="{% url "spirit:topic:notification:index-unread" %}"
+            >{% trans "Unread notifications" %}</a></li>
+        </ul>
+      {% endspaceless %}
     </div>
   </div>
   <div class="menu__button">

--- a/spirit/topic/notification/templates/spirit/topic/notification/index.html
+++ b/spirit/topic/notification/templates/spirit/topic/notification/index.html
@@ -6,7 +6,7 @@
 
 {% block content %}
   <div class="layout__article">
-    {% include "spirit/topic/notification/_top_bar.html" %}
+    {% include "spirit/topic/notification/_top_bar.html" with active="notifications" %}
 
     {% include "spirit/topic/notification/_render_list.html" %}
 

--- a/spirit/topic/notification/templates/spirit/topic/notification/index_unread.html
+++ b/spirit/topic/notification/templates/spirit/topic/notification/index_unread.html
@@ -1,0 +1,29 @@
+{% extends "spirit/_base.html" %}
+
+{% load spirit_tags i18n %}
+
+{% block title %}{% trans "Unread notifications" %}{% endblock %}
+
+{% block content %}
+  <div class="layout__article">
+    {% include "spirit/topic/notification/_top_bar.html" with active="unread_notifications" %}
+
+    {% if page %}
+      {% include "spirit/topic/notification/_render_list.html" with notifications=page %}
+    {% else %}
+      <p>{% trans "There are no new notifications" %}.</p>
+    {% endif %}
+
+    {# TODO: make this a template tag #}
+    {% if page.has_next %}
+      {% spaceless %}
+        <ul class="paginator">
+          <li><a
+            class="paginator__button"
+            href="?p={{ next_page }}"
+          >{% trans "Next" %} <i class="fa fa-chevron-right"></i></a></li>
+        </ul>
+      {% endspaceless %}
+    {% endif %}
+  </div>
+{% endblock %}

--- a/spirit/topic/notification/urls.py
+++ b/spirit/topic/notification/urls.py
@@ -8,6 +8,7 @@ from . import views
 app_name = 'notification'
 urlpatterns = [
     re_path(r'^$', views.index, name='index'),
+    re_path(r'^unread/$', views.index_unread, name='index-unread'),
     re_path(r'^ajax/$', views.index_ajax, name='index-ajax'),
     re_path(r'^(?P<topic_id>[0-9]+)/create/$', views.create, name='create'),
     re_path(r'^(?P<pk>[0-9]+)/update/$', views.update, name='update'),

--- a/spirit/topic/notification/views.py
+++ b/spirit/topic/notification/views.py
@@ -11,10 +11,12 @@ from django.utils.html import escape
 from django.urls import reverse
 
 from djconfig import config
+from infinite_scroll_pagination.serializers import to_page_key
 
 from spirit.core.conf import settings
 from spirit.core import utils
 from spirit.core.utils.paginator import yt_paginate
+from spirit.core.utils.paginator.infinite_paginator import paginate
 from spirit.core.utils.views import is_ajax
 from spirit.topic.models import Topic
 from .models import TopicNotification
@@ -63,7 +65,7 @@ def index_ajax(request):
     notifications = (
         TopicNotification.objects
             .for_access(request.user)
-            .order_by("is_read", "action", "-date", "-pk")
+            .order_by("is_read", "-date")
             .with_related_data())
     notifications = notifications[:settings.ST_NOTIFICATIONS_PER_PAGE]
     notifications = [
@@ -80,11 +82,31 @@ def index_ajax(request):
 
 
 @login_required
+def index_unread(request):
+    notifications = (
+        TopicNotification.objects
+            .for_access(request.user)
+            .filter(is_read=False)
+            .with_related_data())
+    page = paginate(
+        request,
+        query_set=notifications,
+        lookup_field='date',
+        page_var='p',
+        per_page=settings.ST_NOTIFICATIONS_PER_PAGE)
+    return render(
+        request=request,
+        template_name='spirit/topic/notification/index_unread.html',
+        context={
+            'page': page,
+            'next_page': to_page_key(**page.next_page())})
+
+
+@login_required
 def index(request):
     notifications = yt_paginate(
         TopicNotification.objects
             .for_access(request.user)
-            .order_by("is_read", "action", "-date", "-pk")
             .with_related_data(),
         per_page=config.topics_per_page,
         page_number=request.GET.get('page', 1))


### PR DESCRIPTION
Reverts #292

Bah, I remembered why unread/read notifications is not a single list. Basically, because it breaks the pagination. When notifications are marked as read (ex: on visit), and we go to the next page, the next unread notifications will move to the previous page, as the previous page notifications are all read.

The infinite pagination cannot fix this, because the order is not defined by a single field. I'm not sure it can be fixed to handle this case, but I don't think so.