### PR TITLE
improved German translation (2nd attempt)

### DIFF
--- a/spirit/admin/locale/de/LC_MESSAGES/django.po
+++ b/spirit/admin/locale/de/LC_MESSAGES/django.po
@@ -1,18 +1,19 @@
-# 
+#
 # Translators:
 # Sven Hessenmüller <sven.hessenmueller@gmail.com>, 2016
 msgid ""
 msgstr ""
 "Project-Id-Version: Spirit\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2020-10-25 14:24+0000\n"
+"POT-Creation-Date: 2023-11-06 10:33+0100\n"
 "PO-Revision-Date: 2020-10-25 08:52+0000\n"
 "Last-Translator: Esteban Castro Borsani <ecastroborsani@gmail.com>\n"
-"Language-Team: German (http://www.transifex.com/spirit-project/spirit/language/de/)\n"
+"Language-Team: German (http://www.transifex.com/spirit-project/spirit/"
+"language/de/)\n"
+"Language: de\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Language: de\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 
 #: forms.py:11
@@ -61,7 +62,7 @@ msgstr "Themen"
 
 #: templates/spirit/admin/_nav_menu.html:33
 msgid "Users"
-msgstr "Benutzer_innen"
+msgstr "Benutzer"
 
 #: templates/spirit/admin/_nav_menu.html:37
 #: templates/spirit/admin/dashboard.html:42
@@ -97,6 +98,6 @@ msgstr "Kommentare"
 msgid "Likes"
 msgstr "Likes"
 
-#: views.py:27
+#: views.py:28
 msgid "Settings updated!"
 msgstr "Einstellungen aktualisiert!"

--- a/spirit/category/admin/locale/de/LC_MESSAGES/django.po
+++ b/spirit/category/admin/locale/de/LC_MESSAGES/django.po
@@ -1,27 +1,30 @@
-# 
+#
 # Translators:
 msgid ""
 msgstr ""
 "Project-Id-Version: Spirit\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2020-10-25 14:24+0000\n"
+"POT-Creation-Date: 2023-11-06 10:33+0100\n"
 "PO-Revision-Date: 2018-01-30 15:40+0000\n"
 "Last-Translator: Esteban Castro Borsani <ecastroborsani@gmail.com>\n"
-"Language-Team: German (http://www.transifex.com/spirit-project/spirit/language/de/)\n"
+"Language-Team: German (http://www.transifex.com/spirit-project/spirit/"
+"language/de/)\n"
+"Language: de\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Language: de\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 
 #: forms.py:51
 msgid ""
 "The category you are updating can not have a parent since it has childrens"
-msgstr "Der Kategorie die du updatest, kann keine übergeordnete Kategorie zugewiesen werden, da sie selbst untergeordnete Kategorien besitzt."
+msgstr ""
+"Der Kategorie die du updatest, kann keine übergeordnete Kategorie zugewiesen "
+"werden, da sie selbst untergeordnete Kategorien besitzt."
 
 #: forms.py:61
 msgid "The input is not a valid hex color."
-msgstr ""
+msgstr "Die Eingabe ist keine gültige Hex-Farbe."
 
 #: templates/spirit/category/admin/create.html:5
 #: templates/spirit/category/admin/create.html:9
@@ -36,7 +39,7 @@ msgstr "speichern"
 #: templates/spirit/category/admin/index.html:5
 #: templates/spirit/category/admin/index.html:13
 msgid "Category list"
-msgstr "Kategorieliste"
+msgstr "Kategorienliste"
 
 #: templates/spirit/category/admin/index.html:20
 msgid "Create Category"
@@ -45,7 +48,7 @@ msgstr "Kategorie anlegen"
 #: templates/spirit/category/admin/index.html:52
 #: templates/spirit/category/admin/index.html:87
 msgid "edit"
-msgstr "editieren"
+msgstr "bearbeiten"
 
 #: templates/spirit/category/admin/update.html:5
 #: templates/spirit/category/admin/update.html:9

--- a/spirit/category/locale/de/LC_MESSAGES/django.po
+++ b/spirit/category/locale/de/LC_MESSAGES/django.po
@@ -1,4 +1,4 @@
-# 
+#
 # Translators:
 # 5a85a00218ad0559ac6870a4179f4dbc, 2016
 # Sven Hessenmüller <sven.hessenmueller@gmail.com>, 2016
@@ -6,14 +6,15 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Spirit\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2020-10-25 14:24+0000\n"
+"POT-Creation-Date: 2023-11-06 10:33+0100\n"
 "PO-Revision-Date: 2020-09-13 00:53+0000\n"
 "Last-Translator: Esteban Castro Borsani <ecastroborsani@gmail.com>\n"
-"Language-Team: German (http://www.transifex.com/spirit-project/spirit/language/de/)\n"
+"Language-Team: German (http://www.transifex.com/spirit-project/spirit/"
+"language/de/)\n"
+"Language: de\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Language: de\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 
 #: models.py:24
@@ -30,19 +31,19 @@ msgstr "Beschreibung"
 
 #: models.py:33
 msgid "color"
-msgstr ""
+msgstr "Farbe"
 
 #: models.py:34
 msgid "Title color in hex format (i.e: #1aafd0)."
-msgstr ""
+msgstr "Titelfarbe im Hex-Format (z.B.: #1aafd0)."
 
 #: models.py:35
 msgid "sorting order"
-msgstr ""
+msgstr "Sortierreihenfolge"
 
 #: models.py:36
 msgid "modified at"
-msgstr ""
+msgstr "geändert um"
 
 #: models.py:39
 msgid "global"
@@ -51,7 +52,8 @@ msgstr "global"
 #: models.py:41
 msgid ""
 "Designates whether the topics will bedisplayed in the all-categories list."
-msgstr "Gibt an, ob die Themen in der \"Alle-Kategorien\"-Liste angezeigt werden."
+msgstr ""
+"Gibt an, ob die Themen in der \"Alle-Kategorien\"-Liste angezeigt werden."
 
 #: models.py:43
 msgid "closed"

--- a/spirit/comment/bookmark/locale/de/LC_MESSAGES/django.po
+++ b/spirit/comment/bookmark/locale/de/LC_MESSAGES/django.po
@@ -1,17 +1,18 @@
-# 
+#
 # Translators:
 msgid ""
 msgstr ""
 "Project-Id-Version: Spirit\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2020-10-25 14:24+0000\n"
+"POT-Creation-Date: 2023-11-06 10:34+0100\n"
 "PO-Revision-Date: 2018-01-30 15:40+0000\n"
 "Last-Translator: Esteban Castro Borsani <ecastroborsani@gmail.com>\n"
-"Language-Team: German (http://www.transifex.com/spirit-project/spirit/language/de/)\n"
+"Language-Team: German (http://www.transifex.com/spirit-project/spirit/"
+"language/de/)\n"
+"Language: de\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Language: de\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 
 #: models.py:27

--- a/spirit/comment/flag/admin/locale/de/LC_MESSAGES/django.po
+++ b/spirit/comment/flag/admin/locale/de/LC_MESSAGES/django.po
@@ -1,17 +1,18 @@
-# 
+#
 # Translators:
 msgid ""
 msgstr ""
 "Project-Id-Version: Spirit\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2020-10-25 14:24+0000\n"
+"POT-Creation-Date: 2023-11-06 10:34+0100\n"
 "PO-Revision-Date: 2018-11-26 00:01+0000\n"
 "Last-Translator: Esteban Castro Borsani <ecastroborsani@gmail.com>\n"
-"Language-Team: German (http://www.transifex.com/spirit-project/spirit/language/de/)\n"
+"Language-Team: German (http://www.transifex.com/spirit-project/spirit/"
+"language/de/)\n"
+"Language: de\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Language: de\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 
 #: templates/spirit/comment/flag/admin/_list.html:16
@@ -29,12 +30,12 @@ msgstr "geschlossen"
 #: templates/spirit/comment/flag/admin/closed.html:5
 #: templates/spirit/comment/flag/admin/closed.html:11
 msgid "Closed flags"
-msgstr "geschlossene flags"
+msgstr "geschlossene Flags"
 
 #: templates/spirit/comment/flag/admin/detail.html:5
 #: templates/spirit/comment/flag/admin/detail.html:16
 msgid "Flag"
-msgstr "flag"
+msgstr "Flag"
 
 #: templates/spirit/comment/flag/admin/detail.html:11
 msgid "Admin"
@@ -54,7 +55,7 @@ msgstr "speichern"
 
 #: templates/spirit/comment/flag/admin/detail.html:38
 msgid "Comment flagged"
-msgstr "Kommentar gekennzeichnet"
+msgstr "Kommentar geflagged"
 
 #: templates/spirit/comment/flag/admin/detail.html:65
 msgid "delete"
@@ -71,8 +72,8 @@ msgstr "Reporter"
 #: templates/spirit/comment/flag/admin/open.html:5
 #: templates/spirit/comment/flag/admin/open.html:11
 msgid "Open flags"
-msgstr "offene flags"
+msgstr "offene Flags"
 
 #: views.py:27
 msgid "The flag has been moderated!"
-msgstr "Die Flagge wurde moderiert!"
+msgstr "Die Flag wurde moderiert!"

--- a/spirit/comment/flag/locale/de/LC_MESSAGES/django.po
+++ b/spirit/comment/flag/locale/de/LC_MESSAGES/django.po
@@ -1,17 +1,18 @@
-# 
+#
 # Translators:
 msgid ""
 msgstr ""
 "Project-Id-Version: Spirit\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2020-10-25 14:24+0000\n"
+"POT-Creation-Date: 2023-11-06 10:34+0100\n"
 "PO-Revision-Date: 2018-01-30 15:41+0000\n"
 "Last-Translator: Esteban Castro Borsani <ecastroborsani@gmail.com>\n"
-"Language-Team: German (http://www.transifex.com/spirit-project/spirit/language/de/)\n"
+"Language-Team: German (http://www.transifex.com/spirit-project/spirit/"
+"language/de/)\n"
+"Language: de\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Language: de\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 
 #: forms.py:30
@@ -24,15 +25,15 @@ msgstr "Spam"
 
 #: models.py:11
 msgid "Other"
-msgstr "anders"
+msgstr "Andere"
 
 #: models.py:31
 msgid "comment flag"
-msgstr "Kommentar flag"
+msgstr "Kommentar-Flag"
 
 #: models.py:32
 msgid "comments flags"
-msgstr "Kommentar flag"
+msgstr "Kommentare-Flag"
 
 #: models.py:49
 msgid "reason"

--- a/spirit/comment/history/locale/de/LC_MESSAGES/django.po
+++ b/spirit/comment/history/locale/de/LC_MESSAGES/django.po
@@ -1,26 +1,27 @@
-# 
+#
 # Translators:
 msgid ""
 msgstr ""
 "Project-Id-Version: Spirit\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2020-10-25 14:24+0000\n"
+"POT-Creation-Date: 2023-11-06 10:34+0100\n"
 "PO-Revision-Date: 2018-01-30 15:40+0000\n"
 "Last-Translator: Esteban Castro Borsani <ecastroborsani@gmail.com>\n"
-"Language-Team: German (http://www.transifex.com/spirit-project/spirit/language/de/)\n"
+"Language-Team: German (http://www.transifex.com/spirit-project/spirit/"
+"language/de/)\n"
+"Language: de\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Language: de\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 
 #: models.py:13
 msgid "original comment"
-msgstr "originaler Kommentar"
+msgstr "ursprünglicher Kommentar"
 
 #: models.py:16
 msgid "comment html"
-msgstr "comment html"
+msgstr "Kommentar-HTML"
 
 #: models.py:21
 msgid "comment history"
@@ -28,9 +29,9 @@ msgstr "Kommentar-Verlauf"
 
 #: models.py:22
 msgid "comments history"
-msgstr "Kommentar-Verlauf"
+msgstr "Kommentare-Verlauf"
 
 #: templates/spirit/comment/history/detail.html:5
 #: templates/spirit/comment/history/detail.html:11
 msgid "Comment history"
-msgstr "Kommentarverlauf"
+msgstr "Kommentar-Verlauf"

--- a/spirit/comment/like/locale/de/LC_MESSAGES/django.po
+++ b/spirit/comment/like/locale/de/LC_MESSAGES/django.po
@@ -1,30 +1,31 @@
-# 
+#
 # Translators:
 msgid ""
 msgstr ""
 "Project-Id-Version: Spirit\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2020-10-25 14:24+0000\n"
+"POT-Creation-Date: 2023-11-06 10:34+0100\n"
 "PO-Revision-Date: 2018-01-30 15:40+0000\n"
 "Last-Translator: Esteban Castro Borsani <ecastroborsani@gmail.com>\n"
-"Language-Team: German (http://www.transifex.com/spirit-project/spirit/language/de/)\n"
+"Language-Team: German (http://www.transifex.com/spirit-project/spirit/"
+"language/de/)\n"
+"Language: de\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Language: de\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 
 #: forms.py:28
 msgid "This like already exists"
-msgstr "like existiert bereits"
+msgstr "Like existiert bereits"
 
 #: models.py:27
 msgid "like"
-msgstr "like"
+msgstr "Like"
 
 #: models.py:28
 msgid "likes"
-msgstr "likes"
+msgstr "Likes"
 
 #: templates/spirit/comment/like/create.html:5
 #: templates/spirit/comment/like/create.html:18
@@ -39,9 +40,9 @@ msgstr "Like %(username)ss Kommentar"
 #: templates/spirit/comment/like/delete.html:5
 #: templates/spirit/comment/like/delete.html:17
 msgid "Remove like"
-msgstr "like entfernen"
+msgstr "Like entfernen"
 
 #: templates/spirit/comment/like/delete.html:10
 #, python-format
 msgid "Remove %(username)s's comment like"
-msgstr "Entferne %(username)ss Kommentarlike"
+msgstr "Entferne %(username)ss Kommentar-Like"

--- a/spirit/comment/locale/de/LC_MESSAGES/django.po
+++ b/spirit/comment/locale/de/LC_MESSAGES/django.po
@@ -1,18 +1,19 @@
-# 
+#
 # Translators:
 # 5a85a00218ad0559ac6870a4179f4dbc, 2016
 msgid ""
 msgstr ""
 "Project-Id-Version: Spirit\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2020-10-25 14:24+0000\n"
+"POT-Creation-Date: 2023-11-06 10:34+0100\n"
 "PO-Revision-Date: 2020-09-18 20:23+0000\n"
 "Last-Translator: Esteban Castro Borsani <ecastroborsani@gmail.com>\n"
-"Language-Team: German (http://www.transifex.com/spirit-project/spirit/language/de/)\n"
+"Language-Team: German (http://www.transifex.com/spirit-project/spirit/"
+"language/de/)\n"
+"Language: de\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Language: de\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 
 #: forms.py:50
@@ -30,7 +31,7 @@ msgstr "Nicht unterstütztes Dateiformat. Unterstützte Formate sind %s."
 
 #: forms.py:184 forms.py:203
 msgid "The file could not be validated"
-msgstr ""
+msgstr "Die Datei konnte nicht validiert werden"
 
 #: forms.py:190
 #, python-format
@@ -38,12 +39,15 @@ msgid ""
 "Unsupported file extension %(extension)s. Supported extensions are "
 "%(supported)s."
 msgstr ""
+"Nicht-unterstützte Dateinamenerweiterung %(extension)s. Die unterstützten "
+"Erweiterungen sind %(supported)s."
 
 #: forms.py:208
 #, python-format
-msgid ""
-"Unsupported file mime type %(mime)s. Supported types are %(supported)s."
+msgid "Unsupported file mime type %(mime)s. Supported types are %(supported)s."
 msgstr ""
+"Nicht-unterstützter MIME-Typ %(mime)s. Die unterstützten Typen sind "
+"%(supported)s."
 
 #: models.py:16 models.py:31 models.py:46
 msgid "comment"
@@ -59,7 +63,7 @@ msgstr "Thema geschlossen"
 
 #: models.py:19
 msgid "topic unclosed"
-msgstr "Thema geöffnet"
+msgstr "Thema wieder geöffnet"
 
 #: models.py:20
 msgid "topic pinned"
@@ -67,11 +71,11 @@ msgstr "Thema festheften"
 
 #: models.py:21
 msgid "topic unpinned"
-msgstr "Thema nicht festgeheftet"
+msgstr "Heftung bei Thema aufgehoben"
 
 #: models.py:32
 msgid "comment html"
-msgstr "comment html"
+msgstr "Kommentar-HTML"
 
 #: models.py:33
 msgid "action"
@@ -83,7 +87,7 @@ msgstr "modifizierter Zähler"
 
 #: models.py:40
 msgid "likes count"
-msgstr "likes count"
+msgstr "Likes-Anzahl"
 
 #: models.py:47
 msgid "comments"
@@ -92,32 +96,32 @@ msgstr "Kommentare"
 #: tags.py:42
 #, python-brace-format
 msgid "{user} moved this {time_ago}"
-msgstr ""
+msgstr "{user} verschob dies {time_ago}"
 
 #: tags.py:43
 #, python-brace-format
 msgid "{user} closed this {time_ago}"
-msgstr ""
+msgstr "{user} verschob dies {time_ago}"
 
 #: tags.py:44
 #, python-brace-format
 msgid "{user} reopened this {time_ago}"
-msgstr ""
+msgstr "{user} eröffnete dies {time_ago} neu"
 
 #: tags.py:45
 #, python-brace-format
 msgid "{user} pinned this {time_ago}"
-msgstr ""
+msgstr "{user} heftete dies {time_ago} fest"
 
 #: tags.py:46
 #, python-brace-format
 msgid "{user} unpinned this {time_ago}"
-msgstr ""
+msgstr "{user} hob diese Heftung {time_ago} auf"
 
 #: tags.py:56
 #, python-brace-format
 msgid "{user}'s comment was removed {time_ago}"
-msgstr ""
+msgstr "{user}s Kommentar wurde {time_ago} entfernt"
 
 #: templates/spirit/comment/_editor.html:9
 msgid "Bold"
@@ -141,7 +145,7 @@ msgstr "Bild"
 
 #: templates/spirit/comment/_editor.html:36
 msgid "File"
-msgstr ""
+msgstr "Datei"
 
 #: templates/spirit/comment/_editor.html:43
 msgid "Poll"
@@ -155,7 +159,7 @@ msgstr "Vorschau"
 #: templates/spirit/comment/_editor.html:86
 #, python-brace-format
 msgid "uploading {name}"
-msgstr ""
+msgstr "lade {name} hoch"
 
 #: templates/spirit/comment/_editor.html:93
 msgid "bolded text"
@@ -187,11 +191,11 @@ msgstr "Bild-URL"
 
 #: templates/spirit/comment/_editor.html:100
 msgid "file text"
-msgstr ""
+msgstr "Dateitext"
 
 #: templates/spirit/comment/_editor.html:101
 msgid "file url"
-msgstr ""
+msgstr "Datei-URL"
 
 #: templates/spirit/comment/_editor.html:102
 msgid "Title"
@@ -213,7 +217,7 @@ msgstr "wiederherstellen"
 
 #: templates/spirit/comment/_render_list.html:33
 msgid "show"
-msgstr ""
+msgstr "anzeigen"
 
 #: templates/spirit/comment/_render_list.html:61
 msgid "Admin"
@@ -221,11 +225,11 @@ msgstr "Admin"
 
 #: templates/spirit/comment/_render_list.html:63
 msgid "Moderator"
-msgstr ""
+msgstr "Moderator"
 
 #: templates/spirit/comment/_render_list.html:66
 msgid "Original Poster"
-msgstr ""
+msgstr "ursprünglicher Ersteller"
 
 #: templates/spirit/comment/_render_list.html:91
 msgid "delete"
@@ -237,12 +241,12 @@ msgstr "melden"
 
 #: templates/spirit/comment/_render_list.html:99
 msgid "share"
-msgstr "Teilen"
+msgstr "teilen"
 
 #: templates/spirit/comment/_render_list.html:107
 #: templates/spirit/comment/_render_list.html:168
 msgid "remove like"
-msgstr "like entfernen"
+msgstr "Like entfernen"
 
 #: templates/spirit/comment/_render_list.html:114
 #: templates/spirit/comment/_render_list.html:167
@@ -251,7 +255,7 @@ msgstr "like"
 
 #: templates/spirit/comment/_render_list.html:122
 msgid "edit"
-msgstr "editieren"
+msgstr "bearbeiten"
 
 #: templates/spirit/comment/_render_list.html:127
 msgid "quote"
@@ -281,4 +285,4 @@ msgstr "Kommentar veröffentlichen zu"
 #: templates/spirit/comment/update.html:5
 #: templates/spirit/comment/update.html:9
 msgid "Edit comment"
-msgstr "Kommentar editieren"
+msgstr "Kommentar bearbeiten"

--- a/spirit/comment/poll/locale/de/LC_MESSAGES/django.po
+++ b/spirit/comment/poll/locale/de/LC_MESSAGES/django.po
@@ -1,20 +1,21 @@
 # SOME DESCRIPTIVE TITLE.
 # Copyright (C) YEAR THE PACKAGE'S COPYRIGHT HOLDER
 # This file is distributed under the same license as the PACKAGE package.
-# 
+#
 # Translators:
 msgid ""
 msgstr ""
 "Project-Id-Version: Spirit\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2020-10-25 14:24+0000\n"
+"POT-Creation-Date: 2023-11-06 10:34+0100\n"
 "PO-Revision-Date: 2015-10-14 21:05+0000\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
-"Language-Team: German (http://www.transifex.com/spirit-project/spirit/language/de/)\n"
+"Language-Team: German (http://www.transifex.com/spirit-project/spirit/"
+"language/de/)\n"
+"Language: de\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Language: de\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 
 #: forms.py:29 forms.py:35
@@ -24,12 +25,12 @@ msgstr "Auswahlmöglichkeiten"
 #: forms.py:61
 #, python-format
 msgid "Too many selected choices. Limit is %s"
-msgstr "Zu viel ausgewählt. Das Limit beträgt %s"
+msgstr "Zu viele Möglichkeiten ausgewählt. Das Limit beträgt %s"
 
 #: forms.py:67
 #, python-format
 msgid "Too few selected choices. Minimum is %s"
-msgstr ""
+msgstr "Zu wenige Möglichkeiten ausgewählt. Das Minimum beträgt %s"
 
 #: forms.py:77
 msgid "This poll is closed"
@@ -37,7 +38,7 @@ msgstr "Diese Umfrage ist geschlossen"
 
 #: models.py:34
 msgid "name"
-msgstr ""
+msgstr "Name"
 
 #: models.py:35
 msgid "title"
@@ -45,31 +46,31 @@ msgstr "Titel"
 
 #: models.py:36
 msgid "choice min"
-msgstr ""
+msgstr "Auswahl-Minimum"
 
 #: models.py:37
 msgid "choice max"
-msgstr ""
+msgstr "Auswahl-Maximum"
 
 #: models.py:38
 msgid "mode"
-msgstr ""
+msgstr "Modus"
 
 #: models.py:39
 msgid "auto close at"
-msgstr ""
+msgstr "automatisch schließen um"
 
 #: models.py:47
 msgid "comment poll"
-msgstr ""
+msgstr "Kommentar-Umfrage"
 
 #: models.py:48
 msgid "comments polls"
-msgstr ""
+msgstr "Kommentare-Umfrage"
 
 #: models.py:135
 msgid "number"
-msgstr ""
+msgstr "Nummer"
 
 #: models.py:136
 msgid "choice description"
@@ -77,38 +78,38 @@ msgstr "Auswahlbeschreibung"
 
 #: models.py:137
 msgid "vote count"
-msgstr ""
+msgstr "Stimmen-Anzahl"
 
 #: models.py:145
 msgid "poll choice"
-msgstr "Auswahl"
+msgstr "Auswahlmöglichkeit"
 
 #: models.py:146
 msgid "poll choices"
-msgstr ""
+msgstr "Auswahlmöglichkeiten"
 
 #: models.py:220
 msgid "poll vote"
-msgstr ""
+msgstr "Stimme"
 
 #: models.py:221
 msgid "poll votes"
-msgstr ""
+msgstr "Stimmen"
 
 #: templates/spirit/comment/poll/_form.html:23
 #, python-format
 msgid "Closes on %(date)s."
-msgstr ""
+msgstr "schließt am %(date)s."
 
 #: templates/spirit/comment/poll/_form.html:29
 #, python-format
 msgid "You must select %(choice_min)s choices."
-msgstr ""
+msgstr "Du musst mindestens %(choice_min)s Möglichkeiten auswählen."
 
 #: templates/spirit/comment/poll/_form.html:33
 #, python-format
 msgid "You may select up to %(choice_max)s choices."
-msgstr ""
+msgstr "Du darfst höchstens %(choice_max)s Möglichkeiten auswählen."
 
 #: templates/spirit/comment/poll/_form.html:37
 #, python-format
@@ -116,45 +117,48 @@ msgid ""
 "You may select no less than %(choice_min)s and no more than %(choice_max)s "
 "choices."
 msgstr ""
+"Du musst mindestens %(choice_min)s und darfst höchstens %(choice_max)s "
+"Möglichkeiten auswählen."
 
 #: templates/spirit/comment/poll/_form.html:43
 msgid "Results will be available when the poll is closed."
 msgstr ""
+"Die Ergebnisse werden verfügbar sein, wenn die Umfrage geschlossen ist."
 
 #: templates/spirit/comment/poll/_form.html:52
 msgid "Vote"
-msgstr "Abstimmen"
+msgstr "abstimmen"
 
 #: templates/spirit/comment/poll/_form.html:58
 msgid "Show results"
-msgstr ""
+msgstr "Ergebnisse anzeigen"
 
 #: templates/spirit/comment/poll/_form.html:66
 #: templates/spirit/comment/poll/_results.html:45
 msgid "open"
-msgstr ""
+msgstr "offen"
 
 #: templates/spirit/comment/poll/_form.html:71
 #: templates/spirit/comment/poll/_results.html:50
 msgid "close"
-msgstr "Schließen"
+msgstr "schließen"
 
 #: templates/spirit/comment/poll/_results.html:15
 #, python-format
 msgid "%(choice)s, %(percentage)s%%"
-msgstr ""
+msgstr "%(choice)s, %(percentage)s%%"
 
 #: templates/spirit/comment/poll/_results.html:19
 msgid "View voters"
-msgstr ""
+msgstr "Wähler anzeigen"
 
 #: templates/spirit/comment/poll/_results.html:29
 msgid "Votes"
-msgstr ""
+msgstr "Stimmen"
 
 #: templates/spirit/comment/poll/_results.html:37
 msgid "Show vote choices"
-msgstr ""
+msgstr "Auswahlmöglichkeiten anzeigen"
 
 #: templates/spirit/comment/poll/_static.html:27
 #, python-format
@@ -162,6 +166,8 @@ msgid ""
 "Name: %(poll_name)s, choice selection: from %(choice_min)s up to "
 "%(choice_max)s, mode: %(mode)s, close at: %(close_at)s"
 msgstr ""
+"Name: %(poll_name)s, Auswahlmöglichkeiten: von %(choice_min)s bis "
+"%(choice_max)s, Modus: %(mode)s, schließt um: %(close_at)s"
 
 #: templates/spirit/comment/poll/_static.html:31
 #, python-format
@@ -169,9 +175,11 @@ msgid ""
 "Name: %(poll_name)s, choice selection: from %(choice_min)s up to "
 "%(choice_max)s, mode: %(mode)s"
 msgstr ""
+"Name: %(poll_name)s, Auswahlmöglichkeiten: von %(choice_min)s bis "
+"%(choice_max)s, Modus: %(mode)s"
 
 #: templates/spirit/comment/poll/voters.html:5
 #: templates/spirit/comment/poll/voters.html:10
 #, python-format
 msgid "Voters for %(choice_description)s"
-msgstr ""
+msgstr "Stimmen für %(choice_description)s"

--- a/spirit/core/locale/de/LC_MESSAGES/django.po
+++ b/spirit/core/locale/de/LC_MESSAGES/django.po
@@ -1,4 +1,4 @@
-# 
+#
 # Translators:
 # 5a85a00218ad0559ac6870a4179f4dbc, 2017
 # Sven Hessenmüller <sven.hessenmueller@gmail.com>, 2016
@@ -6,14 +6,15 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Spirit\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2020-10-25 14:24+0000\n"
+"POT-Creation-Date: 2023-11-06 10:33+0100\n"
 "PO-Revision-Date: 2020-10-25 08:52+0000\n"
 "Last-Translator: Esteban Castro Borsani <ecastroborsani@gmail.com>\n"
-"Language-Team: German (http://www.transifex.com/spirit-project/spirit/language/de/)\n"
+"Language-Team: German (http://www.transifex.com/spirit-project/spirit/"
+"language/de/)\n"
+"Language: de\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Language: de\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 
 #: tags/time.py:32
@@ -38,16 +39,16 @@ msgstr "%(count)sStd."
 #: tasks.py:208
 #, python-brace-format
 msgid "{user} commented on {topic}"
-msgstr ""
+msgstr "{user} kommentierte {topic}"
 
 #: tasks.py:218
 #, python-brace-format
 msgid "{user} mention you on {topic}"
-msgstr ""
+msgstr "{user} erwähnte dich am {topic}"
 
 #: tasks.py:250
 msgid "New notifications"
-msgstr ""
+msgstr "neue Benachrichtigungen"
 
 #: templates/403.html:10
 msgid "You do not have sufficient permissions to access this page"
@@ -55,12 +56,12 @@ msgstr "Unzureichende Rechte zum aufrufen dieser Seite"
 
 #: templates/404.html:10
 msgid "what you are looking for is gone..."
-msgstr "was Du suchst ist nicht mehr hier..."
+msgstr "Was du suchst ist nicht mehr hier..."
 
 #: templates/spirit/_base.html:29
 #, python-brace-format
 msgid "{user} has mention you on {topic}"
-msgstr "{user} erwähnte Dich in {topic}"
+msgstr "{user} erwähnte dich unter {topic}"
 
 #: templates/spirit/_base.html:30
 #, python-brace-format
@@ -69,7 +70,7 @@ msgstr "{user} kommentierte {topic}"
 
 #: templates/spirit/_base.html:31
 msgid "Show all"
-msgstr "Zeige alles"
+msgstr "zeige alles"
 
 #: templates/spirit/_base.html:32
 msgid "No new notifications, yet"

--- a/spirit/search/locale/de/LC_MESSAGES/django.po
+++ b/spirit/search/locale/de/LC_MESSAGES/django.po
@@ -1,17 +1,18 @@
-# 
+#
 # Translators:
 msgid ""
 msgstr ""
 "Project-Id-Version: Spirit\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2020-10-25 14:24+0000\n"
+"POT-Creation-Date: 2023-11-06 10:33+0100\n"
 "PO-Revision-Date: 2018-01-30 15:40+0000\n"
 "Last-Translator: Esteban Castro Borsani <ecastroborsani@gmail.com>\n"
-"Language-Team: German (http://www.transifex.com/spirit-project/spirit/language/de/)\n"
+"Language-Team: German (http://www.transifex.com/spirit-project/spirit/"
+"language/de/)\n"
+"Language: de\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Language: de\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 
 #: forms.py:22

--- a/spirit/topic/admin/locale/de/LC_MESSAGES/django.po
+++ b/spirit/topic/admin/locale/de/LC_MESSAGES/django.po
@@ -1,17 +1,18 @@
-# 
+#
 # Translators:
 msgid ""
 msgstr ""
 "Project-Id-Version: Spirit\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2020-10-25 14:24+0000\n"
+"POT-Creation-Date: 2023-11-06 10:34+0100\n"
 "PO-Revision-Date: 2018-01-30 15:40+0000\n"
 "Last-Translator: Esteban Castro Borsani <ecastroborsani@gmail.com>\n"
-"Language-Team: German (http://www.transifex.com/spirit-project/spirit/language/de/)\n"
+"Language-Team: German (http://www.transifex.com/spirit-project/spirit/"
+"language/de/)\n"
+"Language: de\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Language: de\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 
 #: templates/spirit/topic/admin/_tabs.html:7

--- a/spirit/topic/favorite/locale/de/LC_MESSAGES/django.po
+++ b/spirit/topic/favorite/locale/de/LC_MESSAGES/django.po
@@ -1,17 +1,18 @@
-# 
+#
 # Translators:
 msgid ""
 msgstr ""
 "Project-Id-Version: Spirit\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2020-10-25 14:24+0000\n"
+"POT-Creation-Date: 2023-11-06 10:34+0100\n"
 "PO-Revision-Date: 2018-01-30 15:41+0000\n"
 "Last-Translator: Esteban Castro Borsani <ecastroborsani@gmail.com>\n"
-"Language-Team: German (http://www.transifex.com/spirit-project/spirit/language/de/)\n"
+"Language-Team: German (http://www.transifex.com/spirit-project/spirit/"
+"language/de/)\n"
+"Language: de\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Language: de\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 
 #: forms.py:28

--- a/spirit/topic/locale/de/LC_MESSAGES/django.po
+++ b/spirit/topic/locale/de/LC_MESSAGES/django.po
@@ -1,18 +1,19 @@
-# 
+#
 # Translators:
 # Sven Hessenmüller <sven.hessenmueller@gmail.com>, 2016
 msgid ""
 msgstr ""
 "Project-Id-Version: Spirit\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2020-10-25 14:24+0000\n"
+"POT-Creation-Date: 2023-11-06 10:33+0100\n"
 "PO-Revision-Date: 2020-09-13 00:53+0000\n"
 "Last-Translator: Esteban Castro Borsani <ecastroborsani@gmail.com>\n"
-"Language-Team: German (http://www.transifex.com/spirit-project/spirit/language/de/)\n"
+"Language-Team: German (http://www.transifex.com/spirit-project/spirit/"
+"language/de/)\n"
+"Language: de\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Language: de\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 
 #: forms.py:33
@@ -41,7 +42,7 @@ msgstr "zuletzt aktiv"
 
 #: models.py:39
 msgid "reindex at"
-msgstr ""
+msgstr "reindizieren um"
 
 #: models.py:41
 msgid "pinned"
@@ -57,7 +58,7 @@ msgstr "geschlossen"
 
 #: models.py:46
 msgid "views count"
-msgstr "gelesen"
+msgstr "Anzahl gelesen"
 
 #: models.py:47
 msgid "comment count"
@@ -95,15 +96,15 @@ msgstr "zuletzt aktive Themen"
 
 #: templates/spirit/topic/detail.html:12
 msgid "Main"
-msgstr "Main"
+msgstr "Start"
 
 #: templates/spirit/topic/detail.html:39 templates/spirit/topic/detail.html:43
 msgid "edit"
-msgstr "editieren"
+msgstr "bearbeiten"
 
 #: templates/spirit/topic/detail.html:51
 msgid "Moderate"
-msgstr ""
+msgstr "moderieren"
 
 #: templates/spirit/topic/detail.html:57
 msgid "Select comments to move"
@@ -111,7 +112,7 @@ msgstr "Kommentar zum verschieben auswählen"
 
 #: templates/spirit/topic/detail.html:60
 msgid "Undelete topic"
-msgstr "Thema wiederherstellen"
+msgstr "Löschung des Themas rückgängig machen"
 
 #: templates/spirit/topic/detail.html:63
 msgid "Delete topic"
@@ -127,15 +128,15 @@ msgstr "Thema schließen"
 
 #: templates/spirit/topic/detail.html:74
 msgid "Unpin topic"
-msgstr "Thema loslösen"
+msgstr "Heftung bei Thema aufheben"
 
 #: templates/spirit/topic/detail.html:77
 msgid "Pin topic"
-msgstr "Thema gefestigen"
+msgstr "Thema festheften"
 
 #: templates/spirit/topic/detail.html:81
 msgid "Unpin topic globally"
-msgstr "Thema global loslösen"
+msgstr "globale Heftung des Themas aufheben"
 
 #: templates/spirit/topic/detail.html:84
 msgid "Pin topic globally"
@@ -147,11 +148,11 @@ msgstr "Antworten"
 
 #: templates/spirit/topic/detail.html:114
 msgid "Move selected comments to"
-msgstr ""
+msgstr "ausgewählte Kommentare verschieben nach"
 
 #: templates/spirit/topic/detail.html:120
 msgid "Move"
-msgstr "verschiebe"
+msgstr "verschieben"
 
 #: templates/spirit/topic/moderate.html:5
 #: templates/spirit/topic/moderate.html:9
@@ -160,10 +161,9 @@ msgstr "Thema moderieren"
 
 #: templates/spirit/topic/moderate.html:14
 msgid "Apply"
-msgstr "akzeptieren"
+msgstr "anwenden"
 
-#: templates/spirit/topic/publish.html:5
-#: templates/spirit/topic/publish.html:20
+#: templates/spirit/topic/publish.html:5 templates/spirit/topic/publish.html:20
 msgid "Publish topic"
 msgstr "Thema veröffentlichen"
 

--- a/spirit/topic/moderate/locale/de/LC_MESSAGES/django.po
+++ b/spirit/topic/moderate/locale/de/LC_MESSAGES/django.po
@@ -1,0 +1,51 @@
+# SOME DESCRIPTIVE TITLE.
+# Copyright (C) YEAR THE PACKAGE'S COPYRIGHT HOLDER
+# This file is distributed under the same license as the PACKAGE package.
+# FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
+#
+#, fuzzy
+msgid ""
+msgstr ""
+"Project-Id-Version: PACKAGE VERSION\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2023-11-06 10:34+0100\n"
+"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
+"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
+"Language-Team: LANGUAGE <LL@li.org>\n"
+"Language: \n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=2; plural=(n != 1);\n"
+
+#: views.py:51
+msgid "The topic has been deleted"
+msgstr "Das Thema wurde gelöscht"
+
+#: views.py:60
+msgid "The topic has been undeleted"
+msgstr "Die Löschung des Themas wurde rückgängig gemacht"
+
+#: views.py:70
+msgid "The topic has been locked"
+msgstr "Das Thema wurde gesperrt"
+
+#: views.py:80
+msgid "The topic has been unlocked"
+msgstr "Die Sperrung des Themas wurde aufgehoben"
+
+#: views.py:90
+msgid "The topic has been pinned"
+msgstr "Das Thema wurde festgeheftet"
+
+#: views.py:100
+msgid "The topic has been unpinned"
+msgstr "Die Heftung des Themas wurde aufgehoben"
+
+#: views.py:110
+msgid "The topic has been globally pinned"
+msgstr "Das Thema wurde global festgeheftet"
+
+#: views.py:120
+msgid "The topic has been globally unpinned"
+msgstr "Die globale Heftung des Themas wurde aufgehoben"

--- a/spirit/topic/notification/locale/de/LC_MESSAGES/django.po
+++ b/spirit/topic/notification/locale/de/LC_MESSAGES/django.po
@@ -1,18 +1,19 @@
-# 
+#
 # Translators:
 # 5a85a00218ad0559ac6870a4179f4dbc, 2016
 msgid ""
 msgstr ""
 "Project-Id-Version: Spirit\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2020-10-25 14:24+0000\n"
+"POT-Creation-Date: 2023-11-06 10:34+0100\n"
 "PO-Revision-Date: 2020-10-25 08:53+0000\n"
 "Last-Translator: Esteban Castro Borsani <ecastroborsani@gmail.com>\n"
-"Language-Team: German (http://www.transifex.com/spirit-project/spirit/language/de/)\n"
+"Language-Team: German (http://www.transifex.com/spirit-project/spirit/"
+"language/de/)\n"
+"Language: de\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Language: de\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 
 #: forms.py:35
@@ -49,21 +50,25 @@ msgstr "Benachrichtigung abstellen"
 
 #: templates/spirit/topic/notification/_form.html:14
 msgid "Notify Me"
-msgstr "Benachrichtige Mich"
+msgstr "benachrichtige mich"
 
 #: templates/spirit/topic/notification/_render_list.html:11
 #, python-format
 msgid ""
 "<a href=\"%(url_profile)s\">%(username)s</a> has commented on <a "
 "href=\"%(url_topic)s\">%(topic_title)s</a>"
-msgstr "<a href=\"%(url_profile)s\">%(username)s</a> kommentierte zu <a href=\"%(url_topic)s\">%(topic_title)s</a>"
+msgstr ""
+"<a href=\"%(url_profile)s\">%(username)s</a> kommentierte zu <a "
+"href=\"%(url_topic)s\">%(topic_title)s</a>"
 
 #: templates/spirit/topic/notification/_render_list.html:15
 #, python-format
 msgid ""
 "<a href=\"%(url_profile)s\">%(username)s</a> has mention you on <a "
 "href=\"%(url_topic)s\">%(topic_title)s</a>"
-msgstr "<a href=\"%(url_profile)s\">%(username)s</a> erwähnte Dich in <a href=\"%(url_topic)s\">%(topic_title)s</a>"
+msgstr ""
+"<a href=\"%(url_profile)s\">%(username)s</a> erwähnte Dich in <a "
+"href=\"%(url_topic)s\">%(topic_title)s</a>"
 
 #: templates/spirit/topic/notification/_render_list.html:22
 msgid "unread"
@@ -87,26 +92,26 @@ msgstr "Ungelesene Benachrichtigungen"
 
 #: templates/spirit/topic/notification/_top_bar.html:38
 msgid "Mark All As Read"
-msgstr ""
+msgstr "alle als gelesen markieren"
 
 #: templates/spirit/topic/notification/email_notification.html:2
 #: templates/spirit/topic/notification/email_notification_weekly.html:2
 #, python-format
 msgid "You have a new notification on %(site_name)s."
-msgstr ""
+msgstr "Du hast eine neue Benachrichtigung auf %(site_name)s."
 
 #: templates/spirit/topic/notification/email_notification.html:6
 msgid "View comment"
-msgstr ""
+msgstr "Kommentar anzeigen"
 
 #: templates/spirit/topic/notification/email_notification.html:10
 #: templates/spirit/topic/notification/email_notification_weekly.html:10
 msgid "Unsubscribe"
-msgstr ""
+msgstr "abbestellen"
 
 #: templates/spirit/topic/notification/email_notification_weekly.html:6
 msgid "View notifications"
-msgstr ""
+msgstr "Benachrichtigungen anzeigen"
 
 #: templates/spirit/topic/notification/index_unread.html:14
 msgid "There are no new notifications"

--- a/spirit/topic/private/locale/de/LC_MESSAGES/django.po
+++ b/spirit/topic/private/locale/de/LC_MESSAGES/django.po
@@ -1,22 +1,23 @@
-# 
+#
 # Translators:
 msgid ""
 msgstr ""
 "Project-Id-Version: Spirit\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2020-10-25 14:24+0000\n"
+"POT-Creation-Date: 2023-11-06 10:34+0100\n"
 "PO-Revision-Date: 2018-01-30 15:40+0000\n"
 "Last-Translator: Esteban Castro Borsani <ecastroborsani@gmail.com>\n"
-"Language-Team: German (http://www.transifex.com/spirit-project/spirit/language/de/)\n"
+"Language-Team: German (http://www.transifex.com/spirit-project/spirit/"
+"language/de/)\n"
+"Language: de\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Language: de\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 
 #: forms.py:75
 msgid "Invite users"
-msgstr ""
+msgstr "Benutzer einladen"
 
 #: forms.py:85
 msgid "user1, user2, ..."
@@ -24,16 +25,16 @@ msgstr "User1, User2, ..."
 
 #: forms.py:120
 msgid "Invite user"
-msgstr "User einladen"
+msgstr "Benutzer einladen"
 
 #: forms.py:127
 msgid "username"
-msgstr "Username"
+msgstr "Benutzername"
 
 #: forms.py:142 forms.py:177
 #, python-format
 msgid "%(username)s is already a participant"
-msgstr "%(username)s ist bereits Teilnehmer_in"
+msgstr "%(username)s ist bereits Teilnehmer"
 
 #: models.py:29
 msgid "private topic"
@@ -63,7 +64,7 @@ msgstr "Neues privates Thema erstellen"
 
 #: templates/spirit/topic/private/delete.html:5
 msgid "Remove user from private topic"
-msgstr "Entferne Benutzer_in vom privaten Thema"
+msgstr "Entferne Benutzer vom privaten Thema"
 
 #: templates/spirit/topic/private/delete.html:10
 #, python-format
@@ -81,7 +82,7 @@ msgstr "private Themen"
 
 #: templates/spirit/topic/private/detail.html:23
 msgid "Participants"
-msgstr "Teilnehmer_innen"
+msgstr "Teilnehmer"
 
 #: templates/spirit/topic/private/detail.html:50
 msgid "Leave topic"
@@ -101,12 +102,12 @@ msgstr "Es gibt keine Themen, bis jetzt..."
 
 #: templates/spirit/topic/private/join.html:5
 msgid "Join topic"
-msgstr "Diskussion beitreten"
+msgstr "Thema beitreten"
 
 #: templates/spirit/topic/private/join.html:10
 #, python-format
 msgid "Do you want to join %(topic_title)s?"
-msgstr "Willst du dieser Diskussion beitreten %(topic_title)s?"
+msgstr "Willst du dem Thema %(topic_title)s beitreten?"
 
 #: templates/spirit/topic/private/join.html:20
 msgid "Join"

--- a/spirit/topic/unread/locale/de/LC_MESSAGES/django.po
+++ b/spirit/topic/unread/locale/de/LC_MESSAGES/django.po
@@ -1,17 +1,18 @@
-# 
+#
 # Translators:
 msgid ""
 msgstr ""
 "Project-Id-Version: Spirit\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2020-10-25 14:24+0000\n"
+"POT-Creation-Date: 2023-11-06 10:34+0100\n"
 "PO-Revision-Date: 2018-01-30 15:41+0000\n"
 "Last-Translator: Esteban Castro Borsani <ecastroborsani@gmail.com>\n"
-"Language-Team: German (http://www.transifex.com/spirit-project/spirit/language/de/)\n"
+"Language-Team: German (http://www.transifex.com/spirit-project/spirit/"
+"language/de/)\n"
+"Language: de\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Language: de\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 
 #: models.py:26
@@ -25,7 +26,7 @@ msgstr "ungelesene Themen"
 #: templates/spirit/topic/unread/index.html:5
 #: templates/spirit/topic/unread/index.html:9
 msgid "Unread topics replies"
-msgstr "Ungelesene Themenantworten"
+msgstr "ungelesene Antworten"
 
 #: templates/spirit/topic/unread/index.html:19
 msgid "Next"

--- a/spirit/user/admin/locale/de/LC_MESSAGES/django.po
+++ b/spirit/user/admin/locale/de/LC_MESSAGES/django.po
@@ -1,22 +1,23 @@
-# 
+#
 # Translators:
 msgid ""
 msgstr ""
 "Project-Id-Version: Spirit\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2020-10-25 14:24+0000\n"
+"POT-Creation-Date: 2023-11-06 10:33+0100\n"
 "PO-Revision-Date: 2018-01-30 15:40+0000\n"
 "Last-Translator: Esteban Castro Borsani <ecastroborsani@gmail.com>\n"
-"Language-Team: German (http://www.transifex.com/spirit-project/spirit/language/de/)\n"
+"Language-Team: German (http://www.transifex.com/spirit-project/spirit/"
+"language/de/)\n"
+"Language: de\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Language: de\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 
 #: templates/spirit/user/admin/_list.html:15
 msgid "edit"
-msgstr "editieren"
+msgstr "bearbeiten"
 
 #: templates/spirit/user/admin/_tabs.html:8
 msgid "List"
@@ -41,7 +42,7 @@ msgstr "inaktiv"
 #: templates/spirit/user/admin/edit.html:5
 #: templates/spirit/user/admin/edit.html:9
 msgid "Edit user"
-msgstr "Benutzer editieren"
+msgstr "Benutzer bearbeiten"
 
 #: templates/spirit/user/admin/edit.html:16
 msgid "Save"
@@ -50,13 +51,13 @@ msgstr "speichern"
 #: templates/spirit/user/admin/index.html:5
 #: templates/spirit/user/admin/index.html:11
 msgid "User list"
-msgstr "Benutzer_innenliste"
+msgstr "Benutzerliste"
 
 #: templates/spirit/user/admin/unactive.html:5
 #: templates/spirit/user/admin/unactive.html:11
 msgid "Unactive Users"
 msgstr "inaktive Benutzer"
 
-#: views.py:26
+#: views.py:27
 msgid "This profile has been updated!"
 msgstr "Das Profil wurde aktualisiert!"

--- a/spirit/user/auth/locale/de/LC_MESSAGES/django.po
+++ b/spirit/user/auth/locale/de/LC_MESSAGES/django.po
@@ -1,4 +1,4 @@
-# 
+#
 # Translators:
 # 5a85a00218ad0559ac6870a4179f4dbc, 2016
 # Sven Hessenmüller <sven.hessenmueller@gmail.com>, 2016
@@ -6,14 +6,15 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Spirit\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2020-10-25 14:24+0000\n"
+"POT-Creation-Date: 2023-11-06 10:33+0100\n"
 "PO-Revision-Date: 2018-01-30 15:40+0000\n"
 "Last-Translator: Sven Hessenmüller <sven.hessenmueller@gmail.com>\n"
-"Language-Team: German (http://www.transifex.com/spirit-project/spirit/language/de/)\n"
+"Language-Team: German (http://www.transifex.com/spirit-project/spirit/"
+"language/de/)\n"
+"Language: de\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Language: de\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 
 #: forms.py:19
@@ -22,7 +23,8 @@ msgstr "E-Mail Bestätigung"
 
 #: forms.py:22
 msgid "Enter the same email as above, for verification."
-msgstr "Gib die selbe E-Mail-Adresse wie oben ein, um Tippfehler auszuschließen."
+msgstr ""
+"Gib die selbe E-Mail-Adresse wie oben ein, um Tippfehler auszuschließen."
 
 #: forms.py:25
 msgid "Password"
@@ -38,15 +40,15 @@ msgstr "Dieses Feld nicht ausfüllen."
 
 #: forms.py:61
 msgid "The username is taken."
-msgstr "Der Username ist vergeben."
+msgstr "Der Benutzername ist vergeben."
 
 #: forms.py:74
 msgid "The two email fields didn't match."
-msgstr "Die beiden Email Felder stimmen nicht überein."
+msgstr "Die beiden E-Mail Felder stimmen nicht überein."
 
 #: forms.py:87
 msgid "Username or Email"
-msgstr "Username oder E-Mail"
+msgstr "Benutzername oder E-Mail"
 
 #: forms.py:92
 msgid "The password is not valid."
@@ -63,7 +65,7 @@ msgstr "E-Mail"
 
 #: forms.py:154
 msgid "The provided email does not exists."
-msgstr "Die angegebene Email existiert nicht."
+msgstr "Die angegebene E-Mail existiert nicht."
 
 #: forms.py:165
 msgid "This account is verified, try logging-in."
@@ -73,11 +75,11 @@ msgstr "Dieser Account ist verifiziert, versuche dich anzumelden"
 #: templates/spirit/user/auth/activation_resend.html:9
 #: templates/spirit/user/auth/login.html:26
 msgid "Resend activation email"
-msgstr "Aktivationsmail erneut senden"
+msgstr "Aktivierungs-E-Mail erneut senden"
 
 #: templates/spirit/user/auth/activation_resend.html:15
 msgid "Resend email"
-msgstr "Email erneut senden"
+msgstr "E-Mail erneut senden"
 
 #: templates/spirit/user/auth/login.html:5
 #: templates/spirit/user/auth/login.html:9
@@ -131,31 +133,40 @@ msgstr "Zurücksetzen des Passworts nicht erfolgreich"
 msgid ""
 "The password reset link was invalid, possibly because it has already been "
 "used. Please request a new password reset."
-msgstr "Der Link zum Passwort zurücksetzen war ungültig. Möglicherweise war er schon benutzt. Bitte fordere ein nochmaliges Zurücksetzen des Passwortes an."
+msgstr ""
+"Der Link zum Passwort zurücksetzen war ungültig. Möglicherweise war er schon "
+"benutzt. Bitte fordere neuerlich das Zurücksetzen des Passworts an."
 
 #: templates/spirit/user/auth/password_reset_done.html:5
 #: templates/spirit/user/auth/password_reset_done.html:9
 msgid "Password reset successful"
-msgstr "Zurücksetzen des Passwortes erfolgreich"
+msgstr "Zurücksetzen des Passworts erfolgreich"
 
 #: templates/spirit/user/auth/password_reset_done.html:11
 msgid ""
 "We've emailed you instructions for setting your password. You should be "
 "receiving them shortly."
-msgstr "Wir haben dir eine Anleitung zum zurücksetzen deines Passwortes per E-Mail gesendet. Du solltest sie in Kürze erhalten."
+msgstr ""
+"Wir haben dir eine Anleitung zum zurücksetzen deines Passworts per E-Mail "
+"gesendet. Du solltest sie in Kürze erhalten."
 
-#: templates/spirit/user/auth/password_reset_done.html:12 views.py:149
+#: templates/spirit/user/auth/password_reset_done.html:12 views.py:151
 msgid ""
 "If you don't receive an email, please make sure you've entered the address "
 "you registered with, and check your spam folder."
-msgstr "Wenn du keine E-Mail erhältst, überprüfe bitte ob du die E-Mailadresse angegeben hast, mit welcher du registriert bist und überprüfe deinen SPAM-Ordner."
+msgstr ""
+"Wenn du keine E-Mail erhältst, überprüfe bitte ob du die E-Mail-Adresse "
+"angegeben hast, mit welcher du registriert bist und überprüfe deinen SPAM-"
+"Ordner."
 
 #: templates/spirit/user/auth/password_reset_email.html:2
 #, python-format
 msgid ""
 "You're receiving this email because you requested a password reset for your "
 "user account at %(site_name)s."
-msgstr "Du erhältst diese Email da du um das Zurücksetzen deines Passwortes bei %(site_name)s angesucht hast."
+msgstr ""
+"Du erhältst diese E-Mail da du um das Zurücksetzen deines Passworts bei "
+"%(site_name)s angesucht hast."
 
 #: templates/spirit/user/auth/password_reset_email.html:7
 msgid "Please go to the following page and choose a new password:"
@@ -190,16 +201,18 @@ msgstr "Passwort zurücksetzen unter %(site_name)s"
 msgid "Register"
 msgstr "Registrieren"
 
-#: tests/tests.py:173 tests/tests.py:322
+#: tests/tests.py:178 tests/tests.py:327
 msgid "User activation"
 msgstr "Benutzer-Aktivierung"
 
-#: views.py:106
+#: views.py:108
 #, python-format
 msgid ""
 "We have sent you an email to %(email)s so you can activate your account!"
-msgstr "Wir haben dir eine E-Mail an %(email)s gesandt damit du deinen Zugang aktivieren kannst!"
+msgstr ""
+"Wir haben dir eine E-Mail an %(email)s gesandt damit du deinen Zugang "
+"aktivieren kannst!"
 
-#: views.py:129
+#: views.py:131
 msgid "Your account has been activated!"
 msgstr "Dein Zugang wurde aktiviert!"

--- a/spirit/user/locale/de/LC_MESSAGES/django.po
+++ b/spirit/user/locale/de/LC_MESSAGES/django.po
@@ -1,18 +1,19 @@
-# 
+#
 # Translators:
 # Sven Hessenmüller <sven.hessenmueller@gmail.com>, 2016
 msgid ""
 msgstr ""
 "Project-Id-Version: Spirit\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2020-10-25 14:24+0000\n"
+"POT-Creation-Date: 2023-11-06 10:33+0100\n"
 "PO-Revision-Date: 2020-10-25 08:53+0000\n"
 "Last-Translator: Esteban Castro Borsani <ecastroborsani@gmail.com>\n"
-"Language-Team: German (http://www.transifex.com/spirit-project/spirit/language/de/)\n"
+"Language-Team: German (http://www.transifex.com/spirit-project/spirit/"
+"language/de/)\n"
+"Language: de\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Language: de\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 
 #: forms.py:39
@@ -33,23 +34,23 @@ msgstr "Das eingegebene Passwort ist falsch."
 
 #: forms.py:79
 msgid "Remove avatar"
-msgstr ""
+msgstr "Avatar entfernen"
 
 #: forms.py:88
 msgid "Time zone"
-msgstr ""
+msgstr "Zeitzone"
 
 #: forms.py:90
 msgid "Email notifications"
-msgstr ""
+msgstr "E-Mail Benachrichtigungen"
 
 #: forms.py:92
 msgid "Email mentions"
-msgstr ""
+msgstr "E-Mail Erwähnungen"
 
 #: forms.py:94
 msgid "Email replies"
-msgstr ""
+msgstr "E-Mail Antworten"
 
 #: forms.py:104
 #, python-format
@@ -59,19 +60,19 @@ msgstr "Aktuelle Zeit: %(date)s %(time)s"
 #: forms.py:123
 #, python-format
 msgid "Unsupported file format. Supported formats are %s."
-msgstr "Nicht unterstütztes Dateiformat. Unterstützte Formate sind %s."
+msgstr "Nicht-unterstütztes Dateiformat. Unterstützte Formate sind %s."
 
 #: models.py:30
 msgid "Never"
-msgstr ""
+msgstr "nie"
 
 #: models.py:31
 msgid "Immediately"
-msgstr ""
+msgstr "sofort"
 
 #: models.py:32
 msgid "Weekly"
-msgstr ""
+msgstr "wöchentlich"
 
 #: models.py:37
 msgid "profile"
@@ -79,7 +80,7 @@ msgstr "Profil"
 
 #: models.py:42
 msgid "nickname"
-msgstr ""
+msgstr "Nickname"
 
 #: models.py:43
 msgid "location"
@@ -91,7 +92,7 @@ msgstr "zuletzt gesehen"
 
 #: models.py:45
 msgid "last ip"
-msgstr "letzte ip"
+msgstr "letzte IP"
 
 #: models.py:46
 msgid "time zone"
@@ -99,15 +100,15 @@ msgstr "Zeitzone"
 
 #: models.py:48
 msgid "avatar"
-msgstr ""
+msgstr "Avatar"
 
 #: models.py:52
 msgid "administrator status"
-msgstr "Administrator Status"
+msgstr "Administrator-Status"
 
 #: models.py:53
 msgid "moderator status"
-msgstr "Moderator Status"
+msgstr "Moderator-Status"
 
 #: models.py:55
 msgid "verified"
@@ -117,7 +118,10 @@ msgstr "verifiziert"
 msgid ""
 "Designates whether the user has verified his account by email or by other "
 "means. Un-select this to let the user activate his account."
-msgstr "Zeigt an ob der Benutzer seinen Zugang via E-Mail oder mit anderen Mitteln verifiziert hat. Deaktiviere dieses Feld um den Benutzer (erneut) seinen Zugang aktivieren zu lassen"
+msgstr ""
+"Zeigt an ob der Benutzer seinen Zugang via E-Mail oder mit anderen Mitteln "
+"verifiziert hat. Deaktiviere dieses Feld um den Benutzer (erneut) seinen "
+"Zugang aktivieren zu lassen"
 
 #: models.py:61
 msgid "topic count"
@@ -137,11 +141,11 @@ msgstr ""
 
 #: models.py:68
 msgid "forum profile"
-msgstr "Forum Profil"
+msgstr "Forum-Profil"
 
 #: models.py:69
 msgid "forum profiles"
-msgstr "Forum Profile"
+msgstr "Forum-Profile"
 
 #: templates/spirit/user/_profile.html:22
 msgid "Joined at"
@@ -159,7 +163,7 @@ msgstr "Letzte IP"
 #: templates/spirit/user/profile_update.html:5
 #: templates/spirit/user/profile_update.html:9
 msgid "Preferences"
-msgstr "Vorlieben"
+msgstr "Einstellungen"
 
 #: templates/spirit/user/_profile.html:51
 msgid "Private Message"
@@ -167,7 +171,7 @@ msgstr "Private Nachricht"
 
 #: templates/spirit/user/_profile.html:60
 msgid "Edit user"
-msgstr "Benutzer editieren"
+msgstr "Benutzer bearbeiten"
 
 #: templates/spirit/user/_profile.html:69
 msgid "Comments"
@@ -188,7 +192,8 @@ msgstr "Es gibt noch keine Kommentare, bis jetzt"
 #: templates/spirit/user/activation_email.html:2
 #, python-format
 msgid "You're receiving this email because you registered at %(site_name)s."
-msgstr "Du erhältst diese E-Mail da du dich auf %(site_name)s registriert hast "
+msgstr ""
+"Du erhältst diese E-Mail da du dich auf %(site_name)s registriert hast "
 
 #: templates/spirit/user/activation_email.html:6
 msgid "Please go to the following link to activate your account:"
@@ -203,15 +208,19 @@ msgstr "Danke für das Benutzen unserer Website!"
 #, python-format
 msgid ""
 "You're receiving this because you changed your user email at %(site_name)s."
-msgstr "Du erhältst diese E-Mail, da du deine E-Mailadresse auf %(site_name)s geändert hast."
+msgstr ""
+"Du erhältst diese E-Mail, da du deine E-Mailadresse auf %(site_name)s "
+"geändert hast."
 
 #: templates/spirit/user/email_change_email.html:6
 msgid "Please go to the following link to confirm your email change:"
-msgstr "Bitte klicke auf den folgenden Link um die Änderung deiner E-Mailadresse zu bestätigen:"
+msgstr ""
+"Bitte klicke auf den folgenden Link um die Änderung deiner E-Mailadresse zu "
+"bestätigen:"
 
 #: templates/spirit/user/menu.html:7
 msgid "User menu"
-msgstr "Benutzer_innen Menü"
+msgstr "Benutzermenü"
 
 #: templates/spirit/user/menu.html:11
 msgid "Menu"
@@ -242,18 +251,18 @@ msgid "comments"
 msgstr "Kommentare"
 
 #: templates/spirit/user/profile_email_change.html:5
-#: templates/spirit/user/profile_email_change.html:9 tests.py:632
-#: tests.py:1177 utils/email.py:34
+#: templates/spirit/user/profile_email_change.html:9 tests.py:632 tests.py:1177
+#: utils/email.py:34
 msgid "Email change"
-msgstr "E-Mailadresse ändern"
+msgstr "E-Mail-Adresse ändern"
 
 #: templates/spirit/user/profile_email_change.html:15
 msgid "Change my email"
-msgstr "Meine E-Mailadresse ändern"
+msgstr "Meine E-Mail-Adresse ändern"
 
 #: templates/spirit/user/profile_likes.html:5
 msgid "likes"
-msgstr "likes"
+msgstr "Likes"
 
 #: templates/spirit/user/profile_password_change.html:5
 #: templates/spirit/user/profile_password_change.html:9
@@ -278,7 +287,7 @@ msgstr "speichern"
 
 #: tests.py:1161 utils/email.py:26
 msgid "User activation"
-msgstr "Benutzer_innen-Aktivierung"
+msgstr "Benutzeraktivierung"
 
 #: views.py:39
 msgid "Your profile has been updated!"
@@ -290,7 +299,8 @@ msgstr "Dein Passwort wurde geändert!"
 
 #: views.py:72
 msgid "We have sent you an email so you can confirm the change!"
-msgstr "Wir haben Dir eine E-Mail gesandt, nun kannst du die Änderungen bestätigen!"
+msgstr ""
+"Wir haben Dir eine E-Mail gesandt, nun kannst du die Änderungen bestätigen!"
 
 #: views.py:93
 msgid "Your email has been changed!"
@@ -298,14 +308,16 @@ msgstr "Deine E-Mailadresse wurde geändert!"
 
 #: views.py:96
 msgid "Sorry, we were not able to change your email."
-msgstr "Sorry, es ist uns nicht möglich deine E-Mail-Adresse zu ändern."
+msgstr "Leider ist es uns nicht möglich deine E-Mail-Adresse zu ändern."
 
 #: views.py:107
 msgid "You are now unsubscribed!"
-msgstr ""
+msgstr "Du bist nun nicht mehr abonniert!"
 
 #: views.py:110
 msgid ""
 "Sorry, we were not able to unsubscribed you. Please login and change your "
 "notifications settings."
 msgstr ""
+"Leider ist es uns nicht möglich dein Abonnement aufzuheben. Bitte führe "
+"einen Login durch und ändere deine Benachrichtigungs-Einstellungen."


### PR DESCRIPTION
I took a second stab here at #327, this time without binaries.

Just to repeat the info:

I'm a German native speaker, and I took a stab at improving the German translation tokens.

* added translations for some tokens that previously didn't have any translations at all
* fixed some translations that I found highly unidiomatic.  (For example "Vorlieben" for "Preferences" sounds pretty weird to my ear).
* fixed some inconsistencies in spelling conventions e.g. upper-casing of personal pronouns (e.g. "Du" and "Dich" was previously upper-cased in line with conventions for writing letters in some, but not all cases.  I uniformly used the lower-case version instead).
